### PR TITLE
Associations

### DIFF
--- a/lib/lotus/model/adapters/memory/query.rb
+++ b/lib/lotus/model/adapters/memory/query.rb
@@ -56,6 +56,7 @@ module Lotus
             @dataset    = dataset
             @collection = collection
             @conditions = []
+            @associations = []
             @modifiers  = []
             instance_eval(&blk) if block_given?
           end
@@ -67,7 +68,7 @@ module Lotus
           #
           # @since 0.1.0
           def all
-            @collection.deserialize(run)
+            @collection.deserialize(run, @associations)
           end
 
           # Adds a condition that behaves like SQL `WHERE`.
@@ -408,6 +409,11 @@ module Lotus
           # @see Lotus::Model::Adapters::Sql::Query#negate!
           def negate!
             raise NotImplementedError
+          end
+
+          def preload(association)
+            @associations << association
+            self
           end
 
           protected

--- a/lib/lotus/model/adapters/sql/collection.rb
+++ b/lib/lotus/model/adapters/sql/collection.rb
@@ -27,6 +27,7 @@ module Lotus
           def initialize(dataset, collection)
             super(dataset)
             @collection = collection
+            @associations = []
           end
 
           # Filters the current scope with an `exclude` directive.
@@ -189,7 +190,12 @@ module Lotus
           # @api private
           # @since 0.1.0
           def to_a
-            @collection.deserialize(self)
+            @collection.deserialize(self, @associations)
+          end
+
+          def preload(association)
+            @associations << association
+            self
           end
 
           private

--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -527,6 +527,11 @@ module Lotus
             end
           end
 
+          def preload(association)
+            @collection.preload(association)
+            self
+          end
+
           # Apply all the conditions and returns a filtered collection.
           #
           # This operation is idempotent, and the returned result didn't

--- a/lib/lotus/model/associations/many_to_one.rb
+++ b/lib/lotus/model/associations/many_to_one.rb
@@ -3,14 +3,13 @@ module Lotus
     module Associations
       class ManyToOne
         attr_reader :collection
+        attr_accessor :repository
+
         def initialize(opts)
           @name        = opts.fetch(:name)
           @collection  = opts.fetch(:collection)
           @foreign_key = opts.fetch(:foreign_key) {default_foreign_key}
-        end
-
-        def repository=(repository)
-          @repository = repository
+          @repository  = nil
         end
 
         def associate_entities!(entities)

--- a/lib/lotus/model/associations/many_to_one.rb
+++ b/lib/lotus/model/associations/many_to_one.rb
@@ -1,0 +1,31 @@
+module Lotus
+  module Model
+    module Associations
+      class ManyToOne
+        attr_reader :collection
+        def initialize(opts)
+          @name        = opts.fetch(:name)
+          @collection  = opts.fetch(:collection)
+          @foreign_key = opts.fetch(:foreign_key) {default_foreign_key}
+        end
+
+        def repository=(repository)
+          @repository = repository
+        end
+
+        def associate_entities!(entities)
+          entities.map do |entity|
+            entity.send("#{@name}=", @repository.find(entity.send(@foreign_key)))
+            entity
+          end
+        end
+
+        private
+
+        def default_foreign_key
+          "#{@name}_id"
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/model/associations/one_to_many.rb
+++ b/lib/lotus/model/associations/one_to_many.rb
@@ -1,0 +1,31 @@
+module Lotus
+  module Model
+    module Associations
+      class OneToMany
+        attr_reader :collection
+        def initialize(opts)
+          @name        = opts.fetch(:name)
+          @collection  = opts.fetch(:collection)
+          @foreign_key = opts.fetch(:foreign_key)
+        end
+
+        def repository=(repository)
+          @repository = repository
+        end
+
+        def associate_entities!(entities)
+          entities.map do |entity|
+            entity.send("#{@name}=", by_foreign_key(entity.id))
+            entity
+          end
+        end
+
+        private
+        
+        def by_foreign_key(key)
+          @repository.send(:query).where(@foreign_key => key).to_a
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/model/associations/one_to_many.rb
+++ b/lib/lotus/model/associations/one_to_many.rb
@@ -3,14 +3,13 @@ module Lotus
     module Associations
       class OneToMany
         attr_reader :collection
+        attr_accessor :repository
+
         def initialize(opts)
           @name        = opts.fetch(:name)
           @collection  = opts.fetch(:collection)
           @foreign_key = opts.fetch(:foreign_key)
-        end
-
-        def repository=(repository)
-          @repository = repository
+          @repository  = nil
         end
 
         def associate_entities!(entities)

--- a/lib/lotus/model/mapper.rb
+++ b/lib/lotus/model/mapper.rb
@@ -79,7 +79,7 @@ module Lotus
       # @see Lotus::Model::Mapping::Collection
       def collection(name, &blk)
         if block_given?
-          @collections[name] = Mapping::Collection.new(name, @coercer, &blk)
+          @collections[name] = Mapping::Collection.new(name, @coercer, self, &blk)
         else
           # TODO implement a getter with a private API.
           @collections[name] or raise Mapping::UnmappedCollectionError.new(name)

--- a/lib/lotus/model/mapper.rb
+++ b/lib/lotus/model/mapper.rb
@@ -79,7 +79,7 @@ module Lotus
       # @see Lotus::Model::Mapping::Collection
       def collection(name, &blk)
         if block_given?
-          @collections[name] = Mapping::Collection.new(name, @coercer, self, &blk)
+          @collections[name] = Mapping::Collection.new(name, @coercer, &blk)
         else
           # TODO implement a getter with a private API.
           @collections[name] or raise Mapping::UnmappedCollectionError.new(name)
@@ -93,8 +93,19 @@ module Lotus
       #
       # @since 0.1.0
       def load!
-        @collections.each_value { |collection| collection.load! }
+        @collections.each_value do |collection| 
+          collection.load! 
+          load_associations!(collection)
+        end
         self
+      end
+
+      private
+
+      def load_associations!(_collection)
+        _collection.associations.each_value do |association|
+          association.repository = collection(association.collection).repository
+        end
       end
     end
   end

--- a/lib/lotus/model/mapping/collection.rb
+++ b/lib/lotus/model/mapping/collection.rb
@@ -84,8 +84,8 @@ module Lotus
         # @since 0.1.0
         #
         # @see Lotus::Model::Mapper#collection
-        def initialize(name, coercer_class, mapper, &blk)
-          @name, @coercer_class, @mapper = name, coercer_class, mapper
+        def initialize(name, coercer_class, &blk)
+          @name, @coercer_class = name, coercer_class
           @associations, @attributes = {}, {}
           instance_eval(&blk) if block_given?
         end
@@ -362,7 +362,6 @@ module Lotus
         def load!
           @coercer = coercer_class.new(self)
           configure_repository!
-          load_associations!
         end
 
         private
@@ -375,16 +374,6 @@ module Lotus
         def configure_repository!
           repository.collection = name
           rescue NameError
-        end
-
-        def load_associations!
-          @associations.each do |_, association|
-            association.repository = repository_for(association.collection)
-          end
-        end
-
-        def repository_for(collection)
-          @mapper.collection(collection).repository
         end
 
         def many_to_one(options)

--- a/lib/lotus/model/mapping/collection.rb
+++ b/lib/lotus/model/mapping/collection.rb
@@ -1,3 +1,6 @@
+require 'lotus/model/associations/many_to_one'
+require 'lotus/model/associations/one_to_many'
+
 module Lotus
   module Model
     module Mapping
@@ -70,6 +73,7 @@ module Lotus
         # @api private
         attr_reader :attributes
 
+        attr_reader :associations
         # Instantiate a new collection
         #
         # @param name [Symbol] the name of the mapped collection. If used with a
@@ -80,8 +84,9 @@ module Lotus
         # @since 0.1.0
         #
         # @see Lotus::Model::Mapper#collection
-        def initialize(name, coercer_class, &blk)
-          @name, @coercer_class, @attributes = name, coercer_class, {}
+        def initialize(name, coercer_class, mapper, &blk)
+          @name, @coercer_class, @mapper = name, coercer_class, mapper
+          @associations, @attributes = {}, {}
           instance_eval(&blk) if block_given?
         end
 
@@ -302,6 +307,16 @@ module Lotus
           @attributes[name] = [klass, (options.fetch(:as) { name }).to_sym]
         end
 
+        def association(name, type, options = {})
+          @associations[name] = 
+            if type.is_a? Array
+              one_to_many(options.merge(name: name))
+            else
+              many_to_one(options.merge(name: name))
+            end
+        end
+
+
         # Serializes an entity to be persisted in the database.
         #
         # @param entity [Object] an entity
@@ -318,10 +333,15 @@ module Lotus
         #
         # @api private
         # @since 0.1.0
-        def deserialize(records)
-          records.map do |record|
+        def deserialize(records, associations=[])
+          entities = records.map do |record|
             @coercer.from_record(record)
           end
+
+          associations.each do |association|
+            @associations[association].associate_entities!(entities)
+          end
+          entities
         end
 
         # Deserialize only one attribute from a raw value.
@@ -342,6 +362,7 @@ module Lotus
         def load!
           @coercer = coercer_class.new(self)
           configure_repository!
+          load_associations!
         end
 
         private
@@ -354,6 +375,24 @@ module Lotus
         def configure_repository!
           repository.collection = name
           rescue NameError
+        end
+
+        def load_associations!
+          @associations.each do |_, association|
+            association.repository = repository_for(association.collection)
+          end
+        end
+
+        def repository_for(collection)
+          @mapper.collection(collection).repository
+        end
+
+        def many_to_one(options)
+          Lotus::Model::Associations::ManyToOne.new(options)
+        end
+
+        def one_to_many(options)
+          Lotus::Model::Associations::OneToMany.new(options)
         end
 
         # Retrieves the default repository class

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -1,19 +1,32 @@
 class User
   include Lotus::Entity
-  self.attributes = :name, :age
+  self.attributes = :name, :age, :articles
 end
 
 class Article
   include Lotus::Entity
-  self.attributes = :user_id, :unmapped_attribute, :title, :comments_count
+  self.attributes = :user_id, :category_id, :unmapped_attribute, :title, :comments_count, :user, :category
+end
+
+class Category
+  include Lotus::Entity
+  self.attributes = :articles
 end
 
 class CustomUserRepository
   include Lotus::Repository
 end
 
+class CategoryRepository
+  include Lotus::Repository
+end
+
 class UserRepository
   include Lotus::Repository
+
+  def self.all_with_articles
+    query.preload(:articles)
+  end
 end
 
 class ArticleRepository
@@ -38,6 +51,14 @@ class ArticleRepository
   def self.rank_by_user(user)
     rank.by_user(user)
   end
+
+  def self.all_with_user
+    query.preload(:user)
+  end
+
+  def self.all_with_user_and_category
+    query.preload(:user).preload(:category)
+  end
 end
 
 DB = Sequel.connect(SQLITE_CONNECTION_STRING)
@@ -48,9 +69,14 @@ DB.create_table :users do
   Integer :age
 end
 
+DB.create_table :categories do
+  primary_key :id
+end
+
 DB.create_table :articles do
   primary_key :_id
   Integer :user_id
+  Integer :category_id
   String  :s_title
   String  :comments_count # Not an error: we're testing String => Integer coercion
   String  :umapped_column
@@ -70,6 +96,13 @@ MAPPER = Lotus::Model::Mapper.new do
     attribute :id,   Integer
     attribute :name, String
     attribute :age,  Integer
+    association :articles, [Article], foreign_key: :user_id, collection: :articles 
+  end
+
+  collection :categories do
+    entity Category
+
+    attribute :id,   Integer
   end
 
   collection :articles do
@@ -77,8 +110,11 @@ MAPPER = Lotus::Model::Mapper.new do
 
     attribute :id,             Integer, as: :_id
     attribute :user_id,        Integer
+    attribute :category_id,    Integer
     attribute :title,          String,  as: 's_title'
     attribute :comments_count, Integer
+    association :user, User, foreign_key: :user_id, collection: :users
+    association :category, Category, foreign_key: :category_id, collection: :categories
 
     identity :_id
   end

--- a/test/model/adapters/memory/query_test.rb
+++ b/test/model/adapters/memory/query_test.rb
@@ -13,7 +13,7 @@ describe Lotus::Model::Adapters::Memory::Query do
     end
 
     class MockCollection
-      def deserialize(array)
+      def deserialize(array, _associations=[])
         array
       end
     end

--- a/test/model/associations/many_to_one_test.rb
+++ b/test/model/associations/many_to_one_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+require 'lotus/model/associations/many_to_one'
+
+
+describe Lotus::Model::Associations::ManyToOne do
+  let(:association) {Lotus::Model::Associations::ManyToOne.new(options)}
+
+  let(:user1) do
+    user = User.new(name: 'Uku')
+    UserRepository.create(user)
+    user
+  end
+
+  let(:user2) do
+    user = User.new(name: 'Makis')
+    UserRepository.create(user)
+    user
+  end
+
+
+  describe 'all options present' do
+    let(:options) {
+      {
+        name:              :user, 
+        collection:        :users, 
+        foreign_key:       :user_id, 
+      }
+    }
+
+    it 'associates users for entities with user_id' do
+      articles = [Article.new(user_id: user1.id), Article.new(user_id: user2.id)]
+      association.repository = UserRepository
+      association.associate_entities!(articles)
+
+      articles[0].user.must_equal user1
+      articles[1].user.must_equal user2
+    end
+  end
+
+  describe 'inferring foreign key' do
+    let(:options) {
+      {
+        name:              :user, 
+        collection:        :users, 
+      }
+    }
+
+    it 'associates users for entities with user_id' do
+      articles = [Article.new(user_id: user1.id), Article.new(user_id: user2.id)]
+      association.repository = UserRepository
+      association.associate_entities!(articles)
+
+      articles[0].user.must_equal user1
+      articles[1].user.must_equal user2
+    end
+  end
+end

--- a/test/model/mapper_test.rb
+++ b/test/model/mapper_test.rb
@@ -91,4 +91,26 @@ describe Lotus::Model::Mapper do
       end
     end
   end
+
+  describe '#load!' do
+    let(:association) {Lotus::Model::Associations::OneToMany.new(collection: :articles, foreign_key: :user_id, name: :articles)}
+
+    before do
+      @mapper.collection :users do
+        entity User
+      end
+
+      @mapper.collection :articles do
+        entity Article
+      end
+
+      @mapper.collection(:users).associations[:articles] = association
+    end
+
+    it 'configures repositories for associations' do
+      association.repository.must_be_nil
+      @mapper.load!
+      association.repository.must_equal ArticleRepository
+    end
+  end
 end

--- a/test/model/mapping/coercer_test.rb
+++ b/test/model/mapping/coercer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Lotus::Model::Mapping::Coercer do
   let(:entity) { User.new(name: 'Tyrion Lannister') }
-  let(:collection) { Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer, nil) }
+  let(:collection) { Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer) }
   let(:coercer) { Lotus::Model::Mapping::Coercer.new(collection) }
 
   before do

--- a/test/model/mapping/coercer_test.rb
+++ b/test/model/mapping/coercer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Lotus::Model::Mapping::Coercer do
   let(:entity) { User.new(name: 'Tyrion Lannister') }
-  let(:collection) { Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer) }
+  let(:collection) { Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer, nil) }
   let(:coercer) { Lotus::Model::Mapping::Coercer.new(collection) }
 
   before do

--- a/test/model/mapping/collection_test.rb
+++ b/test/model/mapping/collection_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Lotus::Model::Mapping::Collection do
   before do
-    @collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer, MAPPER)
+    @collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer)
   end
 
   describe '::Boolean' do
@@ -21,7 +21,7 @@ describe Lotus::Model::Mapping::Collection do
     end
 
     it 'executes the given block' do
-      collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer, nil) do
+      collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer) do
         entity User
       end
 

--- a/test/model/mapping/collection_test.rb
+++ b/test/model/mapping/collection_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 describe Lotus::Model::Mapping::Collection do
   before do
-    @collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer)
+    @collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer, MAPPER)
   end
 
   describe '::Boolean' do
@@ -21,7 +21,7 @@ describe Lotus::Model::Mapping::Collection do
     end
 
     it 'executes the given block' do
-      collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer) do
+      collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer, nil) do
         entity User
       end
 
@@ -110,6 +110,21 @@ describe Lotus::Model::Mapping::Collection do
 
     it 'defines a mapped attribute' do
       @collection.attributes[:name].must_equal [String, :t_name]
+    end
+  end
+
+  describe '#association' do
+    before do
+      @collection.association :user, User, foreign_key: :user_id, collection: :users
+      @collection.association :users, [User], foreign_key: :collection_id, collection: :users
+    end
+
+    it 'defines a many to one association' do
+      @collection.associations[:user].must_be_instance_of Lotus::Model::Associations::ManyToOne
+    end
+
+    it 'defines a many to one association' do
+      @collection.associations[:users].must_be_instance_of Lotus::Model::Associations::OneToMany
     end
   end
 end

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -283,7 +283,6 @@ describe Lotus::Repository do
         end
       end
 
-
       describe 'preloading' do
         before do
           UserRepository.create(user1)
@@ -292,15 +291,15 @@ describe Lotus::Repository do
         end
 
         it 'many to one' do
-          articles = ArticleRepository.all_with_user.all
+          articles = ArticleRepository.all_with_user.all.first
 
-          articles.first.user.must_equal user1
+          article.user.must_equal user1
         end
 
         it 'one to many' do
-          associated = UserRepository.all_with_articles.first.articles
+          user = UserRepository.all_with_articles.first
 
-          associated.must_equal [article1]
+          user.articles.must_equal [article1]
         end
 
         it 'allows chaining' do

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -291,7 +291,7 @@ describe Lotus::Repository do
         end
 
         it 'many to one' do
-          articles = ArticleRepository.all_with_user.all.first
+          article = ArticleRepository.all_with_user.all.first
 
           article.user.must_equal user1
         end

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -4,8 +4,9 @@ describe Lotus::Repository do
   let(:user1) { User.new(name: 'L') }
   let(:user2) { User.new(name: 'MG') }
   let(:users) { [user1, user2] }
+  let(:category) { Category.new }
 
-  let(:article1) { Article.new(user_id: user1.id, title: 'Introducing Lotus::Model', comments_count: '23') }
+  let(:article1) { Article.new(category_id: category.id, user_id: user1.id, title: 'Introducing Lotus::Model', comments_count: '23') }
   let(:article2) { Article.new(user_id: user1.id, title: 'Thread safety',            comments_count: '42') }
   let(:article3) { Article.new(user_id: user2.id, title: 'Love Relationships',       comments_count: '4') }
 
@@ -15,12 +16,15 @@ describe Lotus::Repository do
       before do
         UserRepository.adapter    = adapter.new(mapper, uri)
         ArticleRepository.adapter = adapter.new(mapper, uri)
+        CategoryRepository.adapter = adapter.new(mapper, uri)
 
         UserRepository.collection    = :users
         ArticleRepository.collection = :articles
+        CategoryRepository.collection = :categories
 
         UserRepository.clear
         ArticleRepository.clear
+        CategoryRepository.clear
       end
 
       describe '.collection' do
@@ -276,6 +280,34 @@ describe Lotus::Repository do
             actual = ArticleRepository.not_by_user(user1)
             actual.all.must_equal []
           end
+        end
+      end
+
+
+      describe 'preloading' do
+        before do
+          UserRepository.create(user1)
+          CategoryRepository.create(category)
+          ArticleRepository.create(article1)
+        end
+
+        it 'many to one' do
+          articles = ArticleRepository.all_with_user.all
+
+          articles.first.user.must_equal user1
+        end
+
+        it 'one to many' do
+          associated = UserRepository.all_with_articles.first.articles
+
+          associated.must_equal [article1]
+        end
+
+        it 'allows chaining' do
+          article = ArticleRepository.all_with_user_and_category.first
+
+          article.user.must_equal user1
+          article.category.must_equal category
         end
       end
     end


### PR DESCRIPTION
#35 
This is not a final/complete implementation of this feature - the purpose of this pull request is to facilitate discussion around the implementation details of associations.

I want to highlight some issues that I came across with the implementation:

* Visibility - The components of the framework don't have complete knowledge of each other, which is a good design decision, but some parts of this feature feel awkward for this reason. Should the mapping/collection know about it's parent mapper? Should query objects know about the mapping/collection they correspond to? I feel like some parts of this implementation could be cleaner that way.

* Performance - Since this is just a draft, I implemented a naive N+1 query, but I would love to hear ideas on optimizing it.

* Repository's public interface - To fetch associations, I see three options:
  * Reach into the private query object of the target repository. This is what happens in this implementation.
  * Dynamically adding a finder to the target repository when an associations is defined.
  * Add a method on all repositories to fetch records based on a field(e.g. `repository.find_by(:article_id, [1,2,3])`) - essentially exposing the `where` method.
  
  I don't think there's a nice, clean way to do this, we just have to choose the lesser of all the evils.

* `collection#association` api. What has to be specified? What can we infer? How do we distinguish between `belongs_to` and `has_one` ?
