### PR TITLE
Implement SQL inner join

### DIFF
--- a/lib/lotus/model/adapters/sql/collection.rb
+++ b/lib/lotus/model/adapters/sql/collection.rb
@@ -192,6 +192,18 @@ module Lotus
             @mapped_collection.deserialize(self)
           end
 
+          def select_all
+            Collection.new(super(table_name), @mapped_collection)
+          end
+
+          def join_table(*args)
+            Collection.new(super, @mapped_collection)
+          end
+
+          def table_name
+            @mapped_collection.name
+          end
+
           private
           # Serialize the given entity before to persist in the database.
           #

--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -72,7 +72,7 @@ module Lotus
           #
           # @since 0.1.0
           def all
-            Lotus::Utils::Kernel.Array(run)
+            run.to_a
           end
 
           # Adds a SQL `WHERE` condition.
@@ -356,12 +356,26 @@ module Lotus
             self
           end
 
-          def join(collection)
+          def sql
+            scoped.sql
+          end
+
+          def join(collection, options = {})
             # FIXME This is a poor man's singularization, implement in Lotus::Utils
-            foreign_key = "#{ collection.to_s.sub(/s\z/, '') }_id".to_sym
+            collection_name = collection.to_s
+            collection_name = case collection_name
+            when ->(s) { s.match(/ies\z/) }
+              collection_name.sub(/ies\z/, 'y')
+            else
+              collection_name.sub(/s\z/, '')
+            end
+
+            foreign_key = options.fetch(:foreign_key) { "#{ @collection.table_name }__#{ collection_name }_id".to_sym }
+            # FIXME this should correspond to the table's primary key
+            key         = options.fetch(:key) { "#{ collection }__id".to_sym }
 
             conditions.push([:select_all])
-            conditions.push([:join_table, :inner, collection, :id => foreign_key])
+            conditions.push([:join_table, :inner, collection, key => foreign_key])
 
             self
           end

--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -356,6 +356,16 @@ module Lotus
             self
           end
 
+          def join(collection)
+            # FIXME This is a poor man's singularization, implement in Lotus::Utils
+            foreign_key = "#{ collection.to_s.sub(/s\z/, '') }_id".to_sym
+
+            conditions.push([:select_all])
+            conditions.push([:join_table, :inner, collection, :id => foreign_key])
+
+            self
+          end
+
           # Returns the sum of the values for the given column.
           #
           # @param column [Symbol] the column name

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -44,6 +44,7 @@ DB = Sequel.connect(SQLITE_CONNECTION_STRING)
 
 DB.create_table :users do
   primary_key :id
+  Integer :country_id
   String  :name
   Integer :age
 end
@@ -58,12 +59,24 @@ end
 
 DB.create_table :devices do
   primary_key :id
+  Integer     :u_id # user_id: legacy schema simulation
 end
 
 DB.create_table :orders do
   primary_key :id
   Integer :user_id
   Integer :total
+end
+
+DB.create_table :ages do
+  primary_key :id
+  Integer :value
+  String  :label
+end
+
+DB.create_table :countries do
+  primary_key :country_id
+  String :code
 end
 
 # DB.dataset_class = Class.new(Sequel::Dataset)

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -60,6 +60,12 @@ DB.create_table :devices do
   primary_key :id
 end
 
+DB.create_table :orders do
+  primary_key :id
+  Integer :user_id
+  Integer :total
+end
+
 # DB.dataset_class = Class.new(Sequel::Dataset)
 
 #FIXME this should be passed by the framework internals.


### PR DESCRIPTION
## SQL joins

Given the following mapping:

```ruby
Lotus::Model::Mapper.new do
  collection :users do
    entity User

    attribute :id,   Integer
    attribute :country_id, Integer
    attribute :name, String
    attribute :age, Integer
  end

  collection :devices do
    entity Device

    attribute :id, Integer
    attribute :u_id, Integer
  end

  collection :orders do
    entity Order

    attribute :id,      Integer
    attribute :user_id, Integer
    attribute :total,   Integer
  end

  collection :ages do
    entity Age

    attribute :id, Integer
    attribute :value, Integer
    attribute :label, String
  end

  collection :countries do
    entity Country

    attribute :id, Integer, as: :country_id
    attribute :code, String
  end
end
```

### Inner join

#### Default

```ruby
class OrderRepository
  include Lotus::Repository

  def self.foo
    query do
      join(:users)
    end
  end
end
```

```sql
SELECT `orders`.* FROM `orders` INNER JOIN `users` ON (`users`.`id` = `orders`.`user_id`)
```

#### Specify key

```ruby
class UserRepository
  include Lotus::Repository

  def self.foo
    query do
      join(:countries, key: :country_id)
    end
  end
end
```

```sql
SELECT `users`.* FROM `users` INNER JOIN `countries` ON (`countries`.`country_id` = `users`.`country_id`)
```

#### Specify foreign key

```ruby
class DeviceRepository
  include Lotus::Repository

  def self.foo
    query do
      join(:users, foreign_key: :u_id)
    end
  end
end
```

```sql
SELECT `devices`.* FROM `devices` INNER JOIN `users` ON (`users`.`id` = `devices`.`u_id`)
```

#### Specify both key and foreign key

```ruby
class UserRepository
  include Lotus::Repository

  def self.foo
    query do
      join(:ages, key: :value, foreign_key: :age)
    end
  end
end
```

```sql
SELECT `users`.* FROM `users` INNER JOIN `ages` ON (`ages`.`value` = `users`.`age`)
```

Closes #34 