### PR TITLE
[EXPERIMENTAL] Add option :as for Mapper

### DIFF
--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -146,7 +146,22 @@ module Lotus
         # @api private
         # @since 0.1.0
         def _collection(name)
-          Sql::Collection.new(@connection[name], _mapped_collection(name))
+          Sql::Collection.new(_dataset(name), _mapped_collection(name))
+        end
+
+        # Returns the dataset for Sql::Collection
+        #
+        # @param name [Symbol] a name of the collection
+        #
+        # @return [Sequel::Dataset]
+        #
+        # @see Lotus::Model::Adapters::Sql::Collection
+        #
+        # @api private
+        # @since 0.2.0
+        def _dataset(name)
+          _table_name = _mapped_collection(name).table_name
+          @connection[_table_name]
         end
       end
     end

--- a/lib/lotus/model/mapper.rb
+++ b/lib/lotus/model/mapper.rb
@@ -90,17 +90,42 @@ module Lotus
       # A collection is a set of homogeneous records. Think of a table of a SQL
       # database or about collection of MongoDB.
       #
-      # @param name [Symbol] the name of the mapped collection. If used with a
-      #   SQL database it's the table name.
+      # @param name [Symbol] the identifier of the mapped collection. If used with a
+      #   SQL database and :as option is not explicitly given, it's the table name
+      #
+      # @param options [Hash] the options ofthe mapped collection. The :as => :table_name
+      #   option sets the table name
       #
       # @param blk [Proc] the block that maps the attributes of that collection.
       #
       # @since 0.1.0
       #
       # @see Lotus::Model::Mapping::Collection
-      def collection(name, &blk)
+      #
+      # @example Collection with default derived table name
+      #   require 'lotus/model'
+      #
+      #   mapper = Lotus::Model::Mapper.new do
+      #     collection :clients do
+      #     # ...
+      #     end
+      #   end
+      #
+      #   # This sets :clients as the table name
+      #
+      # @example Collection with custom table name
+      #   require 'lotus/model'
+      #
+      #   mapper = Lotus::Model::Mapper.new do
+      #     collection :clients, as: :users do
+      #     # ...
+      #     end
+      #   end
+      #
+      #   # This sets :users as the table name
+      def collection(name, options={}, &blk)
         if block_given?
-          @collections[name] = Mapping::Collection.new(name, @coercer, &blk)
+          @collections[name] = Mapping::Collection.new(name, @coercer, options, &blk)
         else
           @collections[name] or raise Mapping::UnmappedCollectionError.new(name)
         end

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -19,7 +19,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
     end
 
     @mapper = Lotus::Model::Mapper.new do
-      collection :users do
+      collection :clients, as: :users do
         entity TestUser
 
         attribute :id,   Integer
@@ -45,17 +45,17 @@ describe Lotus::Model::Adapters::SqlAdapter do
     Object.send(:remove_const, :TestDeviceRepository)
   end
 
-  let(:collection) { :users }
+  let(:collection) { :clients }
 
   describe 'multiple collections' do
     it 'create records' do
       user   = TestUser.new
       device = TestDevice.new
 
-      @adapter.create(:users, user)
+      @adapter.create(:clients, user)
       @adapter.create(:devices, device)
 
-      @adapter.all(:users).must_equal   [user]
+      @adapter.all(:clients).must_equal [user]
       @adapter.all(:devices).must_equal [device]
     end
   end

--- a/test/model/mapping/collection_test.rb
+++ b/test/model/mapping/collection_test.rb
@@ -16,6 +16,10 @@ describe Lotus::Model::Mapping::Collection do
       @collection.name.must_equal :users
     end
 
+    it 'assigns the table name' do
+      @collection.table_name.must_equal :users
+    end
+
     it 'assigns the coercer class' do
       @collection.coercer_class.must_equal Lotus::Model::Mapping::Coercer
     end
@@ -26,6 +30,14 @@ describe Lotus::Model::Mapping::Collection do
       end
 
       collection.entity.must_equal User
+    end
+
+    describe 'when option :as is provided' do
+      let(:collection) { Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer, as: :clients) }
+
+      it 'assigns the table name' do
+        collection.table_name.must_equal :clients
+      end
     end
   end
 


### PR DESCRIPTION
This override the table_name

Resolves #120 

The idea is to allow collection to have custom table name, this comes useful for the inherited entity usecase. Please see #120 for more details.