### PR TITLE
Coerce entities when persisted

### DIFF
--- a/lib/lotus/model/adapters/file_system_adapter.rb
+++ b/lib/lotus/model/adapters/file_system_adapter.rb
@@ -147,8 +147,7 @@ module Lotus
         # @since 0.2.0
         def create(collection, entity)
           _synchronize do
-            super
-            write(collection)
+            super.tap { write(collection) }
           end
         end
 
@@ -163,8 +162,7 @@ module Lotus
         # @since 0.2.0
         def update(collection, entity)
           _synchronize do
-            super
-            write(collection)
+            super.tap { write(collection) }
           end
         end
 

--- a/lib/lotus/model/adapters/memory/command.rb
+++ b/lib/lotus/model/adapters/memory/command.rb
@@ -33,9 +33,10 @@ module Lotus
           # @api private
           # @since 0.1.0
           def create(entity)
-            @dataset.create(
-              _serialize(entity)
-            )
+            serialized_entity            = _serialize(entity)
+            serialized_entity[_identity] = @dataset.create(serialized_entity)
+
+            _deserialize(serialized_entity)
           end
 
           # Updates the corresponding record for the given entity.
@@ -47,9 +48,10 @@ module Lotus
           # @api private
           # @since 0.1.0
           def update(entity)
-            @dataset.update(
-              _serialize(entity)
-            )
+            serialized_entity = _serialize(entity)
+            @dataset.update(serialized_entity)
+
+            _deserialize(serialized_entity)
           end
 
           # Deletes the corresponding record for the given entity.
@@ -83,6 +85,26 @@ module Lotus
           # @since 0.1.0
           def _serialize(entity)
             @collection.serialize(entity)
+          end
+
+          # Deserialize the given entity after it was persisted in the database.
+          #
+          # @return [Lotus::Entity] the deserialized entity
+          #
+          # @api private
+          # @since x.x.x
+          def _deserialize(entity)
+            @collection.deserialize([entity]).first
+          end
+
+          # Name of the identity column in database
+          #
+          # @return [Symbol] the identity name
+          #
+          # @api private
+          # @since x.x.x
+          def _identity
+            @collection.identity
           end
         end
       end

--- a/lib/lotus/model/adapters/memory_adapter.rb
+++ b/lib/lotus/model/adapters/memory_adapter.rb
@@ -50,8 +50,7 @@ module Lotus
         # @since 0.1.0
         def create(collection, entity)
           synchronize do
-            entity.id = command(collection).create(entity)
-            entity
+            command(collection).create(entity)
           end
         end
 

--- a/lib/lotus/model/adapters/sql/collection.rb
+++ b/lib/lotus/model/adapters/sql/collection.rb
@@ -55,7 +55,10 @@ module Lotus
           # @api private
           # @since 0.1.0
           def insert(entity)
-            super _serialize(entity)
+            serialized_entity            = _serialize(entity)
+            serialized_entity[_identity] = super(serialized_entity)
+
+            _deserialize(serialized_entity)
           end
 
           # Filters the current scope with a `limit` directive.
@@ -178,7 +181,10 @@ module Lotus
           # @api private
           # @since 0.1.0
           def update(entity)
-            super _serialize(entity)
+            serialized_entity = _serialize(entity)
+            super(serialized_entity)
+
+            _deserialize(serialized_entity)
           end
 
           # Resolves self by fetching the records from the database and
@@ -201,6 +207,26 @@ module Lotus
           # @since 0.1.0
           def _serialize(entity)
             @mapped_collection.serialize(entity)
+          end
+
+          # Deserialize the given entity after it was persisted in the database.
+          #
+          # @return [Lotus::Entity] the deserialized entity
+          #
+          # @api private
+          # @since x.x.x
+          def _deserialize(entity)
+            @mapped_collection.deserialize([entity]).first
+          end
+
+          # Name of the identity column in database
+          #
+          # @return [Symbol] the identity name
+          #
+          # @api private
+          # @since x.x.x
+          def _identity
+            @mapped_collection.identity
           end
         end
       end

--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -58,10 +58,9 @@ module Lotus
         # @api private
         # @since 0.1.0
         def create(collection, entity)
-          entity.id = command(
-                        query(collection)
-                      ).create(entity)
-          entity
+          command(
+            query(collection)
+          ).create(entity)
         end
 
         # Updates a record in the database corresponding to the given entity.

--- a/lib/lotus/model/mapping/coercer.rb
+++ b/lib/lotus/model/mapping/coercer.rb
@@ -58,13 +58,16 @@ module Lotus
           instance_eval %{
             def to_record(entity)
               if entity.id
-                Hash[#{ @collection.attributes.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]
+                Hash[#{ @collection.attributes.map{|name,(klass,mapped)| ":#{mapped},Lotus::Model::Mapping::Coercions.#{klass}(entity.#{name})"}.join(',') }]
               else
-                Hash[#{ @collection.attributes.reject{|name,_| name == @collection.identity }.map{|name,(_,mapped)| ":#{mapped},entity.#{name}"}.join(',') }]
+                Hash[#{ @collection.attributes.reject{|name,_| name == @collection.identity }.map{|name,(klass,mapped)| ":#{mapped},Lotus::Model::Mapping::Coercions.#{klass}(entity.#{name})"}.join(',') }]
               end
             end
 
             def from_record(record)
+            if $debug == true
+                raise Hash[#{ @collection.attributes.map{|name,(klass,mapped)| ":#{name},Lotus::Model::Mapping::Coercions.#{klass}(record[:#{mapped}])"}.join(',') }].inspect
+                end
               #{ @collection.entity }.new(
                 Hash[#{ @collection.attributes.map{|name,(klass,mapped)| ":#{name},Lotus::Model::Mapping::Coercions.#{klass}(record[:#{mapped}])"}.join(',') }]
               )

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -253,7 +253,6 @@ module Lotus
       #   article.title # => "Launching Lotus::Model"
       def persist(entity)
         @adapter.persist(collection, entity)
-        entity
       end
 
       # Creates a record in the database for the given entity.
@@ -287,8 +286,6 @@ module Lotus
         unless entity.id
           @adapter.create(collection, entity)
         end
-
-        entity
       end
 
       # Updates a record in the database corresponding to the given entity.
@@ -339,8 +336,6 @@ module Lotus
         else
           raise Lotus::Model::NonPersistedEntityError
         end
-
-        entity
       end
 
       # Deletes a record in the database corresponding to the given entity.

--- a/test/integration/configuration_test.rb
+++ b/test/integration/configuration_test.rb
@@ -31,7 +31,7 @@ describe 'Configuration DSL' do
     it 'add the entity to repositories' do
       @user_counter = UserRepository.all.size
 
-      UserRepository.create(@user)
+      @user = UserRepository.create(@user)
 
       users = UserRepository.all
       users.size.must_equal(@user_counter + 1)

--- a/test/model/adapters/file_system_adapter_test.rb
+++ b/test/model/adapters/file_system_adapter_test.rb
@@ -54,8 +54,8 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
       user   = TestUser.new
       device = TestDevice.new
 
-      @adapter.create(:users, user)
-      @adapter.create(:devices, device)
+      user   = @adapter.create(:users, user)
+      device = @adapter.create(:devices, device)
 
       @verifier.all(:users).must_equal   [user]
       @verifier.all(:devices).must_equal [device]
@@ -100,29 +100,29 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
       let(:entity) { TestUser.new }
 
       it 'stores the record and assigns an id' do
-        @adapter.persist(collection, entity)
+        result = @adapter.persist(collection, entity)
 
-        entity.id.wont_be_nil
-        @verifier.find(collection, entity.id).must_equal entity
+        result.id.wont_be_nil
+        @verifier.find(collection, result.id).must_equal result
       end
     end
 
     describe 'when the given entity is persisted' do
       before do
-        @adapter.create(collection, entity)
+        @entity = @adapter.create(collection, entity)
       end
 
       let(:entity) { TestUser.new }
 
       it 'updates the record and leaves untouched the id' do
-        id = entity.id
+        id = @entity.id
         id.wont_be_nil
 
-        entity.name = 'L'
-        @adapter.persist(collection, entity)
+        @entity.name = 'L'
+        @adapter.persist(collection, @entity)
 
-        entity.id.must_equal(id)
-        @verifier.find(collection, entity.id).name.must_equal entity.name
+        @entity.id.must_equal(id)
+        @verifier.find(collection, @entity.id).name.must_equal @entity.name
       end
     end
   end
@@ -131,28 +131,28 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
     let(:entity) { TestUser.new }
 
     it 'stores the record and assigns an id' do
-      @adapter.create(collection, entity)
+      result = @adapter.create(collection, entity)
 
-      entity.id.wont_be_nil
-      @verifier.find(collection, entity.id).must_equal entity
+      result.id.wont_be_nil
+      @verifier.find(collection, result.id).must_equal result
     end
   end
 
   describe '#update' do
     before do
-      @adapter.create(collection, entity)
+      @entity = @adapter.create(collection, entity)
     end
 
     let(:entity) { TestUser.new(id: nil, name: 'L') }
 
     it 'stores the changes and leave the id untouched' do
-      id = entity.id
+      id = @entity.id
 
-      entity.name = 'MG'
-      @adapter.update(collection, entity)
+      @entity.name = 'MG'
+      @adapter.update(collection, @entity)
 
-      entity.id.must_equal id
-      @verifier.find(collection, entity.id).name.must_equal entity.name
+      @entity.id.must_equal id
+      @verifier.find(collection, @entity.id).name.must_equal @entity.name
     end
   end
 
@@ -182,20 +182,20 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity)
+        @entity = @adapter.create(collection, entity)
       end
 
       let(:entity) { TestUser.new }
 
       it 'returns all of them' do
-        @verifier.all(collection).must_equal [entity]
+        @verifier.all(collection).must_equal [@entity]
       end
     end
   end
 
   describe '#find' do
     before do
-      @adapter.create(collection, entity)
+      @entity = @adapter.create(collection, entity)
       @adapter.instance_variable_get(:@collections).fetch(collection).records.store(nil, nil_entity)
     end
 
@@ -203,7 +203,7 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
     let(:nil_entity)  { {id: 0} }
 
     it 'returns the record by id' do
-      @verifier.find(collection, entity.id).must_equal entity
+      @verifier.find(collection, @entity.id).must_equal @entity
     end
 
     it 'returns nil when the record cannot be found' do
@@ -228,15 +228,15 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity1)
-        @adapter.create(collection, entity2)
+        @entity1 = @adapter.create(collection, entity1)
+        @entity2 = @adapter.create(collection, entity2)
       end
 
       let(:entity1) { TestUser.new }
       let(:entity2) { TestUser.new }
 
       it 'returns the first record' do
-        @verifier.first(collection).must_equal entity1
+        @verifier.first(collection).must_equal @entity1
       end
     end
   end
@@ -254,15 +254,15 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity1)
-        @adapter.create(collection, entity2)
+        @entity1 = @adapter.create(collection, entity1)
+        @entity2 = @adapter.create(collection, entity2)
       end
 
       let(:entity1) { TestUser.new }
       let(:entity2) { TestUser.new }
 
       it 'returns the last record' do
-        @verifier.last(collection).must_equal entity2
+        @verifier.last(collection).must_equal @entity2
       end
     end
   end
@@ -282,8 +282,8 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
     it 'resets the id counter' do
       @adapter.clear(collection)
 
-      @adapter.create(collection, entity)
-      entity.id.must_equal 1
+      result = @adapter.create(collection, entity)
+      result.id.must_equal 1
     end
   end
 
@@ -309,56 +309,56 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
         end
 
         it 'returns selected records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             where(id: id)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'can use multiple where conditions' do
-          id   = user1.id
-          name = user1.name
+          id   = @user1.id
+          name = @user1.name
 
           query = Proc.new {
             where(id: id).where(name: name)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'can use multiple where conditions with "and" alias' do
-          id   = user1.id
-          name = user1.name
+          id   = @user1.id
+          name = @user1.name
 
           query = Proc.new {
             where(id: id).and(name: name)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'requires all conditions be satisfied' do
-          name = user3.name
-          age  = user3.age
+          name = @user3.name
+          age  = @user3.age
 
           query = Proc.new {
             where(age: age).where(name: name)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
       end
     end
@@ -376,46 +376,46 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
         end
 
         let(:user3) { TestUser.new(name: 'S', age: 2) }
 
         it 'returns selected records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             exclude(id: id)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user2, user3]
+          result.must_equal [@user2, @user3]
         end
 
         it 'can use multiple exclude conditions' do
-          id   = user1.id
-          name = user2.name
+          id   = @user1.id
+          name = @user2.name
 
           query = Proc.new {
             exclude(id: id).exclude(name: name)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
 
         it 'can use multiple exclude conditions with "not" alias' do
-          id   = user1.id
-          name = user2.name
+          id   = @user1.id
+          name = @user2.name
 
           query = Proc.new {
             self.not(id: id).not(name: name)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
       end
     end
@@ -433,31 +433,31 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns selected records' do
-          name1 = user1.name
-          name2 = user2.name
+          name1 = @user1.name
+          name2 = @user2.name
 
           query = Proc.new {
             where(name: name1).or(name: name2)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
 
         it 'returns selected records only from the "or" condition' do
-          name2 = user2.name
+          name2 = @user2.name
 
           query = Proc.new {
             where(name: 'unknown').or(name: name2)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user2]
+          result.must_equal [@user2]
         end
       end
     end
@@ -542,8 +542,8 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns sorted records' do
@@ -552,7 +552,7 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
       end
     end
@@ -570,8 +570,8 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns sorted records' do
@@ -580,7 +580,7 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
       end
     end
@@ -598,8 +598,8 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns reverse sorted records' do
@@ -608,7 +608,7 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user2, user1]
+          result.must_equal [@user2, @user1]
         end
       end
     end
@@ -626,20 +626,20 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, TestUser.new(name: user2.name))
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, TestUser.new(name: user2.name))
         end
 
         it 'returns only the number of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).limit(1)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user2]
+          result.must_equal [@user2]
         end
       end
     end
@@ -657,24 +657,24 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
-          @adapter.create(collection, user4)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
+          @user4 = @adapter.create(collection, user4)
         end
 
         let(:user3) { TestUser.new(name: user2.name, age: 31) }
         let(:user4) { TestUser.new(name: user2.name, age: 32) }
 
         it 'returns only the number of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).limit(2).offset(1)
           }
 
           result = @verifier.query(collection, &query).all
-          result.must_equal [user3, user4]
+          result.must_equal [@user3, @user4]
         end
       end
     end
@@ -692,12 +692,12 @@ describe Lotus::Model::Adapters::FileSystemAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns true when there are matched records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             where(id: id)

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -51,8 +51,8 @@ describe Lotus::Model::Adapters::MemoryAdapter do
       user   = TestUser.new
       device = TestDevice.new
 
-      @adapter.create(:users, user)
-      @adapter.create(:devices, device)
+      user   = @adapter.create(:users, user)
+      device = @adapter.create(:devices, device)
 
       @adapter.all(:users).must_equal   [user]
       @adapter.all(:devices).must_equal [device]
@@ -64,29 +64,29 @@ describe Lotus::Model::Adapters::MemoryAdapter do
       let(:entity) { TestUser.new }
 
       it 'stores the record and assigns an id' do
-        @adapter.persist(collection, entity)
+        result = @adapter.persist(collection, entity)
 
-        entity.id.wont_be_nil
-        @adapter.find(collection, entity.id).must_equal entity
+        result.id.wont_be_nil
+        @adapter.find(collection, result.id).must_equal result
       end
     end
 
     describe 'when the given entity is persisted' do
       before do
-        @adapter.create(collection, entity)
+        @entity = @adapter.create(collection, entity)
       end
 
       let(:entity) { TestUser.new }
 
       it 'updates the record and leaves untouched the id' do
-        id = entity.id
+        id = @entity.id
         id.wont_be_nil
 
-        entity.name = 'L'
-        @adapter.persist(collection, entity)
+        @entity.name = 'L'
+        @adapter.persist(collection, @entity)
 
-        entity.id.must_equal(id)
-        @adapter.find(collection, entity.id).name.must_equal entity.name
+        @entity.id.must_equal(id)
+        @adapter.find(collection, @entity.id).name.must_equal @entity.name
       end
     end
   end
@@ -95,28 +95,28 @@ describe Lotus::Model::Adapters::MemoryAdapter do
     let(:entity) { TestUser.new }
 
     it 'stores the record and assigns an id' do
-      @adapter.create(collection, entity)
+      result = @adapter.create(collection, entity)
 
-      entity.id.wont_be_nil
-      @adapter.find(collection, entity.id).must_equal entity
+      result.id.wont_be_nil
+      @adapter.find(collection, result.id).must_equal result
     end
   end
 
   describe '#update' do
     before do
-      @adapter.create(collection, entity)
+      @entity = @adapter.create(collection, entity)
     end
 
     let(:entity) { TestUser.new(id: nil, name: 'L') }
 
     it 'stores the changes and leave the id untouched' do
-      id = entity.id
+      id = @entity.id
 
       entity.name = 'MG'
-      @adapter.update(collection, entity)
+      @adapter.update(collection, @entity)
 
-      entity.id.must_equal id
-      @adapter.find(collection, entity.id).name.must_equal entity.name
+      @entity.id.must_equal id
+      @adapter.find(collection, @entity.id).name.must_equal @entity.name
     end
   end
 
@@ -146,20 +146,20 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity)
+        @entity = @adapter.create(collection, entity)
       end
 
       let(:entity) { TestUser.new }
 
       it 'returns all of them' do
-        @adapter.all(collection).must_equal [entity]
+        @adapter.all(collection).must_equal [@entity]
       end
     end
   end
 
   describe '#find' do
     before do
-      @adapter.create(collection, entity)
+      @entity = @adapter.create(collection, entity)
       @adapter.instance_variable_get(:@collections).fetch(collection).records.store(nil, nil_entity)
     end
 
@@ -167,7 +167,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
     let(:nil_entity)  { {id: 0} }
 
     it 'returns the record by id' do
-      @adapter.find(collection, entity.id).must_equal entity
+      @adapter.find(collection, @entity.id).must_equal @entity
     end
 
     it 'returns nil when the record cannot be found' do
@@ -192,15 +192,15 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity1)
-        @adapter.create(collection, entity2)
+        @entity1 = @adapter.create(collection, entity1)
+        @entity2 = @adapter.create(collection, entity2)
       end
 
       let(:entity1) { TestUser.new }
       let(:entity2) { TestUser.new }
 
       it 'returns the first record' do
-        @adapter.first(collection).must_equal entity1
+        @adapter.first(collection).must_equal @entity1
       end
     end
   end
@@ -218,15 +218,15 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity1)
-        @adapter.create(collection, entity2)
+        @entity1 = @adapter.create(collection, entity1)
+        @entity2 = @adapter.create(collection, entity2)
       end
 
       let(:entity1) { TestUser.new }
       let(:entity2) { TestUser.new }
 
       it 'returns the last record' do
-        @adapter.last(collection).must_equal entity2
+        @adapter.last(collection).must_equal @entity2
       end
     end
   end
@@ -246,8 +246,8 @@ describe Lotus::Model::Adapters::MemoryAdapter do
     it 'resets the id counter' do
       @adapter.clear(collection)
 
-      @adapter.create(collection, entity)
-      entity.id.must_equal 1
+      result = @adapter.create(collection, entity)
+      result.id.must_equal 1
     end
   end
 
@@ -273,56 +273,56 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
         end
 
         it 'returns selected records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             where(id: id)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'can use multiple where conditions' do
-          id   = user1.id
-          name = user1.name
+          id   = @user1.id
+          name = @user1.name
 
           query = Proc.new {
             where(id: id).where(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'can use multiple where conditions with "and" alias' do
-          id   = user1.id
-          name = user1.name
+          id   = @user1.id
+          name = @user1.name
 
           query = Proc.new {
             where(id: id).and(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'requires all conditions be satisfied' do
-          name = user3.name
-          age  = user3.age
+          name = @user3.name
+          age  = @user3.age
 
           query = Proc.new {
             where(age: age).where(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
       end
     end
@@ -340,46 +340,46 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
         end
 
         let(:user3) { TestUser.new(name: 'S', age: 2) }
 
         it 'returns selected records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             exclude(id: id)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2, user3]
+          result.must_equal [@user2, @user3]
         end
 
         it 'can use multiple exclude conditions' do
-          id   = user1.id
-          name = user2.name
+          id   = @user1.id
+          name = @user2.name
 
           query = Proc.new {
             exclude(id: id).exclude(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
 
         it 'can use multiple exclude conditions with "not" alias' do
-          id   = user1.id
-          name = user2.name
+          id   = @user1.id
+          name = @user2.name
 
           query = Proc.new {
             self.not(id: id).not(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
       end
     end
@@ -397,31 +397,31 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns selected records' do
-          name1 = user1.name
-          name2 = user2.name
+          name1 = @user1.name
+          name2 = @user2.name
 
           query = Proc.new {
             where(name: name1).or(name: name2)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
 
         it 'returns selected records only from the "or" condition' do
-          name2 = user2.name
+          name2 = @user2.name
 
           query = Proc.new {
             where(name: 'unknown').or(name: name2)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2]
+          result.must_equal [@user2]
         end
       end
     end
@@ -439,14 +439,15 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
+
+          @users = [@user1, @user2, @user3]
         end
 
         let(:user1) { TestUser.new(name: 'L', age: 32) }
         let(:user3) { TestUser.new(name: 'S') }
-        let(:users) { [user1, user2, user3] }
 
         it 'returns the selected columnts from all the records' do
           query = Proc.new {
@@ -455,7 +456,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
           result = @adapter.query(collection, &query).all
 
-          users.each do |user|
+          @users.each do |user|
             record = result.find {|r| r.age == user.age }
             record.wont_be_nil
             record.name.must_be_nil
@@ -463,7 +464,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it 'returns only the select of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).select(:age)
@@ -472,12 +473,12 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           result = @adapter.query(collection, &query).all
 
           record = result.first
-          record.age.must_equal(user2.age)
+          record.age.must_equal(@user2.age)
           record.name.must_be_nil
         end
 
         it 'returns only the multiple select of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).select(:name, :age)
@@ -486,8 +487,8 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           result = @adapter.query(collection, &query).all
 
           record = result.first
-          record.name.must_equal(user2.name)
-          record.age.must_equal(user2.age)
+          record.name.must_equal(@user2.name)
+          record.age.must_equal(@user2.age)
           record.id.must_be_nil
         end
       end
@@ -506,8 +507,8 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns sorted records' do
@@ -516,7 +517,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
       end
     end
@@ -534,8 +535,8 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns sorted records' do
@@ -544,7 +545,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
       end
     end
@@ -562,8 +563,8 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns reverse sorted records' do
@@ -572,7 +573,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2, user1]
+          result.must_equal [@user2, @user1]
         end
       end
     end
@@ -590,20 +591,20 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, TestUser.new(name: user2.name))
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, TestUser.new(name: user2.name))
         end
 
         it 'returns only the number of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).limit(1)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2]
+          result.must_equal [@user2]
         end
       end
     end
@@ -621,24 +622,24 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
-          @adapter.create(collection, user4)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
+          @user4 = @adapter.create(collection, user4)
         end
 
         let(:user3) { TestUser.new(name: user2.name, age: 31) }
         let(:user4) { TestUser.new(name: user2.name, age: 32) }
 
         it 'returns only the number of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).limit(2).offset(1)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3, user4]
+          result.must_equal [@user3, @user4]
         end
       end
     end
@@ -656,12 +657,12 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns true when there are matched records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             where(id: id)

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -52,8 +52,8 @@ describe Lotus::Model::Adapters::SqlAdapter do
       user   = TestUser.new
       device = TestDevice.new
 
-      @adapter.create(:users, user)
-      @adapter.create(:devices, device)
+      user   = @adapter.create(:users, user)
+      device = @adapter.create(:devices, device)
 
       @adapter.all(:users).must_equal   [user]
       @adapter.all(:devices).must_equal [device]
@@ -85,29 +85,29 @@ describe Lotus::Model::Adapters::SqlAdapter do
       let(:entity) { TestUser.new }
 
       it 'stores the record and assigns an id' do
-        @adapter.persist(collection, entity)
+        result = @adapter.persist(collection, entity)
 
-        entity.id.wont_be_nil
-        @adapter.find(collection, entity.id).must_equal entity
+        result.id.wont_be_nil
+        @adapter.find(collection, result.id).must_equal result
       end
     end
 
     describe 'when the given entity is persisted' do
       before do
-        @adapter.create(collection, entity)
+        @entity = @adapter.create(collection, entity)
       end
 
       let(:entity) { TestUser.new }
 
       it 'updates the record and leaves untouched the id' do
-        id = entity.id
+        id = @entity.id
         id.wont_be_nil
 
-        entity.name = 'L'
-        @adapter.persist(collection, entity)
+        @entity.name = 'L'
+        @adapter.persist(collection, @entity)
 
-        entity.id.must_equal(id)
-        @adapter.find(collection, entity.id).name.must_equal entity.name
+        @entity.id.must_equal(id)
+        @adapter.find(collection, @entity.id).name.must_equal @entity.name
       end
     end
   end
@@ -116,28 +116,28 @@ describe Lotus::Model::Adapters::SqlAdapter do
     let(:entity) { TestUser.new }
 
     it 'stores the record and assigns an id' do
-      @adapter.create(collection, entity)
+      result = @adapter.create(collection, entity)
 
-      entity.id.wont_be_nil
-      @adapter.find(collection, entity.id).must_equal entity
+      result.id.wont_be_nil
+      @adapter.find(collection, result.id).must_equal result
     end
   end
 
   describe '#update' do
     before do
-      @adapter.create(collection, entity)
+      @entity = @adapter.create(collection, entity)
     end
 
     let(:entity) { TestUser.new(id: nil, name: 'L') }
 
     it 'stores the changes and leave the id untouched' do
-      id = entity.id
+      id = @entity.id
 
-      entity.name = 'MG'
-      @adapter.update(collection, entity)
+      @entity.name = 'MG'
+      @adapter.update(collection, @entity)
 
-      entity.id.must_equal id
-      @adapter.find(collection, entity.id).name.must_equal entity.name
+      @entity.id.must_equal id
+      @adapter.find(collection, @entity.id).name.must_equal @entity.name
     end
   end
 
@@ -167,26 +167,26 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity)
+        @entity = @adapter.create(collection, entity)
       end
 
       let(:entity) { TestUser.new }
 
       it 'returns all of them' do
-        @adapter.all(collection).must_equal [entity]
+        @adapter.all(collection).must_equal [@entity]
       end
     end
   end
 
   describe '#find' do
     before do
-      @adapter.create(collection, entity)
+      @entity = @adapter.create(collection, entity)
     end
 
     let(:entity) { TestUser.new }
 
     it 'returns the record by id' do
-      @adapter.find(collection, entity.id).must_equal entity
+      @adapter.find(collection, @entity.id).must_equal @entity
     end
 
     it 'returns nil when the record cannot be found' do
@@ -211,15 +211,15 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity1)
-        @adapter.create(collection, entity2)
+        @entity1 = @adapter.create(collection, entity1)
+        @entity2 = @adapter.create(collection, entity2)
       end
 
       let(:entity1) { TestUser.new }
       let(:entity2) { TestUser.new }
 
       it 'returns the first record' do
-        @adapter.first(collection).must_equal entity1
+        @adapter.first(collection).must_equal @entity1
       end
     end
   end
@@ -237,15 +237,15 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
     describe 'when some records are persisted' do
       before do
-        @adapter.create(collection, entity1)
-        @adapter.create(collection, entity2)
+        @entity1 = @adapter.create(collection, entity1)
+        @entity2 = @adapter.create(collection, entity2)
       end
 
       let(:entity1) { TestUser.new }
       let(:entity2) { TestUser.new }
 
       it 'returns the last record' do
-        @adapter.last(collection).must_equal entity2
+        @adapter.last(collection).must_equal @entity2
       end
     end
   end
@@ -284,43 +284,43 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns selected records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             where(id: id)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'can use multiple where conditions' do
-          id   = user1.id
-          name = user1.name
+          id   = @user1.id
+          name = @user1.name
 
           query = Proc.new {
             where(id: id).where(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'can use multiple where conditions with "and" alias' do
-          id   = user1.id
-          name = user1.name
+          id   = @user1.id
+          name = @user1.name
 
           query = Proc.new {
             where(id: id).and(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'can use lambda to describe where conditions' do
@@ -329,7 +329,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1]
+          result.must_equal [@user1]
         end
 
         it 'raises an error if you dont specify condition or block' do
@@ -356,46 +356,46 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
         end
 
         let(:user3) { TestUser.new(name: 'S', age: 2) }
 
         it 'returns selected records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             exclude(id: id)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2, user3]
+          result.must_equal [@user2, @user3]
         end
 
         it 'can use multiple exclude conditions' do
-          id   = user1.id
-          name = user2.name
+          id   = @user1.id
+          name = @user2.name
 
           query = Proc.new {
             exclude(id: id).exclude(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
 
         it 'can use multiple exclude conditions with "not" alias' do
-          id   = user1.id
-          name = user2.name
+          id   = @user1.id
+          name = @user2.name
 
           query = Proc.new {
             self.not(id: id).not(name: name)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3]
+          result.must_equal [@user3]
         end
 
         it 'can use lambda to describe exclude conditions' do
@@ -404,7 +404,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2, user3]
+          result.must_equal [@user2, @user3]
         end
 
         it 'raises an error if you dont specify condition or block' do
@@ -431,36 +431,36 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns selected records' do
-          name1 = user1.name
-          name2 = user2.name
+          name1 = @user1.name
+          name2 = @user2.name
 
           query = Proc.new {
             where(name: name1).or(name: name2)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
 
         it 'can use lambda to describe or conditions' do
-          name1 = user1.name
+          name1 = @user1.name
 
           query = Proc.new {
             where(name: name1).or{ age < 32 }
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
 
         it 'raises an error if you dont specify condition or block' do
           -> {
-            name1 = user1.name
+            name1 = @user1.name
 
             query = Proc.new {
               where(name: name1).or()
@@ -551,8 +551,8 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns sorted records' do
@@ -561,7 +561,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
 
         it 'returns sorted records, using multiple columns' do
@@ -570,7 +570,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2, user1]
+          result.must_equal [@user2, @user1]
         end
 
         it 'returns sorted records, using multiple invokations' do
@@ -579,7 +579,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2, user1]
+          result.must_equal [@user2, @user1]
         end
       end
     end
@@ -597,8 +597,8 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns sorted records' do
@@ -607,7 +607,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
       end
     end
@@ -625,8 +625,8 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns reverse sorted records' do
@@ -635,7 +635,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2, user1]
+          result.must_equal [@user2, @user1]
         end
 
         it 'returns sorted records, using multiple columns' do
@@ -644,7 +644,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
 
         it 'returns sorted records, using multiple invokations' do
@@ -653,7 +653,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user1, user2]
+          result.must_equal [@user1, @user2]
         end
       end
     end
@@ -671,20 +671,20 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, TestUser.new(name: user2.name))
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, TestUser.new(name: user2.name))
         end
 
         it 'returns only the number of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).limit(1)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user2]
+          result.must_equal [@user2]
         end
       end
     end
@@ -702,24 +702,24 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
-          @adapter.create(collection, user3)
-          @adapter.create(collection, user4)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
+          @user4 = @adapter.create(collection, user4)
         end
 
         let(:user3) { TestUser.new(name: user2.name, age: 31) }
         let(:user4) { TestUser.new(name: user2.name, age: 32) }
 
         it 'returns only the number of requested records' do
-          name = user2.name
+          name = @user2.name
 
           query = Proc.new {
             where(name: name).limit(2).offset(1)
           }
 
           result = @adapter.query(collection, &query).all
-          result.must_equal [user3, user4]
+          result.must_equal [@user3, @user4]
         end
       end
     end
@@ -737,12 +737,12 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
       describe 'with a filled collection' do
         before do
-          @adapter.create(collection, user1)
-          @adapter.create(collection, user2)
+          @user1 = @adapter.create(collection, user1)
+          @user2 = @adapter.create(collection, user2)
         end
 
         it 'returns true when there are matched records' do
-          id = user1.id
+          id = @user1.id
 
           query = Proc.new {
             where(id: id)


### PR DESCRIPTION
Coerce entities when persisted via repositories: `.persist`, `.create` and `.update`.
Those operations will return coerced entities, **without the need of reloading** the record from the database.

Entities are now coerced before to be stored. This will now help schema less databases to receive the expected values (#138).

```ruby
# BEFORE

user = User.new(name: 'L', age: '32')
UserRepository.create(user) # in place assignment of `id`

user.id   # => 1
user.name # => "L"
user.age  # => "32" # WRONG, not coerced

# AFTER

user = User.new(name: 'L', age: '32')
user = UserRepository.create(user) # returns a new instance of `User` with coerced values and `id`

user.id   # => 1
user.name # => "L"
user.age  # => 32 # RIGHT
```

/cc @lotus/core-team 

Closes #138 