### PR TITLE
Add file and line to instance_eval call to make backtrace more usable.

### DIFF
--- a/lib/lotus/model/mapping/coercer.rb
+++ b/lib/lotus/model/mapping/coercer.rb
@@ -55,7 +55,7 @@ module Lotus
             }
           end.join("\n")
 
-          instance_eval %{
+          instance_eval <<-EVAL, __FILE__, __LINE__
             def to_record(entity)
               if entity.id
                 Hash[#{ @collection.attributes.map{|name,(klass,mapped)| ":#{mapped},Lotus::Model::Mapping::Coercions.#{klass}(entity.#{name})"}.join(',') }]
@@ -71,7 +71,7 @@ module Lotus
             end
 
             #{ code }
-          }
+          EVAL
         end
       end
     end


### PR DESCRIPTION
Avoid situations where the backtrace includes an (eval) instead of the name of
the file:

    from (eval):5:in `foo'
    from foo.rb:11