### PR TITLE
Add Lotus::Model::Migration

### DIFF
--- a/lib/lotus/model.rb
+++ b/lib/lotus/model.rb
@@ -72,8 +72,9 @@ module Lotus
     #     end
     #   end
     #
-    # Adapter MUST follow the convention in which adapter class is inflection of adapter name
-    # The above example has name :sql, thus derived class will be `Lotus::Model::Adapters::SqlAdapter`
+    # Adapter MUST follow the convention in which adapter class is inflection
+    # of adapter name. The above example has name :sql, thus derived class will
+    # be `Lotus::Model::Adapters::SqlAdapter`.
     def self.configure(&blk)
       configuration.instance_eval(&blk)
       self
@@ -184,7 +185,9 @@ module Lotus
     #   end
     #
     #   Lotus::Model.configuration.adapter_config # => nil
-    #   MyApp::Model.configuration.adapter_config # => #<Lotus::Model::Config::Adapter:0x007ff0ff0244f8 @type=:memory, @uri="memory://localhost", @class_name="MemoryAdapter">
+    #   MyApp::Model.configuration.adapter_config
+    #     => #<Lotus::Model::Config::Adapter:0x007ff0ff0244f8 @type=:memory,
+    #          @uri="memory://localhost", @class_name="MemoryAdapter">
     def self.duplicate(mod, &blk)
       dupe.tap do |duplicated|
         mod.module_eval %{

--- a/lib/lotus/model/adapters/sql/schema_modifier.rb
+++ b/lib/lotus/model/adapters/sql/schema_modifier.rb
@@ -64,7 +64,7 @@ module Lotus
         # @api private
         class SchemaModifier
           def initialize(adapter, logger = nil)
-            @connection = adapter.instance_variable_get(:@connection)
+            @connection = adapter.connection
             @connection.logger = logger if logger
           end
 

--- a/lib/lotus/model/adapters/sql/schema_modifier.rb
+++ b/lib/lotus/model/adapters/sql/schema_modifier.rb
@@ -1,0 +1,99 @@
+require 'sequel'
+
+module Lotus
+  module Model
+    module Adapters
+      module Sql
+        # Allow users to easily group schema changes and migrate the
+        # database to a newer version or revert to a previous version.
+        #
+        # A migration class must be subclass of Lotus::Model::Migration
+        # and must have 2 instance methods:
+        #
+        #   * up   - to migrate
+        #   * down - to rollback
+        #
+        # Both instance methods could access following schema modification methods:
+        #
+        #   * add_column
+        #   * add_index
+        #   * create_view
+        #   * drop_column
+        #   * drop_index
+        #   * drop_table
+        #   * drop_view
+        #   * rename_table
+        #   * rename_column
+        #   * set_column_default
+        #   * set_column_type
+        #
+        # For more details, please consult documentation
+        # at http://sequel.jeremyevans.net/rdoc/files/doc/schema_modification_rdoc.html
+        #
+        # To apply up/down migration, please consult Lotus::Model::Migration#run
+        # Please avoid running running migration through the low level
+        # Sequel API because doing so does not update the schema_versions table
+        # and thus will create inconsistency in migration history.
+        #
+        # Due to the fact the Sequel is going to kill old class based migration,
+        # it is decided to clone source code from Sequel::Migration.
+        #
+        # @example Create and apply migration
+        #   require 'lotus/model/migration'
+        #
+        #   class MyMigration < Lotus::Model::Migration
+        #     def up
+        #       create_table(:authors) do
+        #         primary_key :id
+        #         String :name
+        #       end
+        #     end
+        #
+        #     def down
+        #       drop_table(:authors)
+        #     end
+        #   end
+        #
+        #   # to apply up migration
+        #   MyMigration.new(adapter).up
+        #
+        #   # to apply down migration
+        #   MyMigration.new(adapter).down
+        #
+        # @since x.x.x
+        # @api private
+        class SchemaModifier
+          def initialize(adapter, logger = nil)
+            @connection = adapter.instance_variable_get(:@connection)
+            @connection.logger = logger if logger
+          end
+
+          private
+
+          # Intercepts method calls intended for the database and sends them along.
+          #
+          # @since x.x.x
+          # @api private
+          def method_missing(method_sym, *args, &block)
+            connection.send(method_sym, *args, &block)
+          end
+
+          # This object responds to all methods the database responds to.
+          #
+          # @since x.x.x
+          # @api private
+          def respond_to_missing?(meth, include_private)
+            connection.respond_to?(meth, include_private)
+          end
+
+          # The DB Connection
+          #
+          # @since x.x.x
+          # @api private
+          attr_reader :connection
+
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/model/configuration.rb
+++ b/lib/lotus/model/configuration.rb
@@ -187,7 +187,7 @@ module Lotus
       #   Lotus::Model.configuration.migrations_directory
       #     # => 'my_custom/migrations'
       #
-      # @since 0.3.0
+      # @since x.x.x
       # @see Lotus::Model.configure
       def migrations_directory(directory=nil)
         if directory.nil?
@@ -283,7 +283,7 @@ module Lotus
 
       # Default directory that contains migration files
       #
-      # @since 0.3.0
+      # @since x.x.x
       # @api private
       def _default_migrations_directory
         Pathname.pwd.join('db', 'migrations')

--- a/lib/lotus/model/configuration.rb
+++ b/lib/lotus/model/configuration.rb
@@ -177,23 +177,23 @@ module Lotus
       # @example Set custom logger and retrieve the set logger
       #   require 'lotus/model'
       #
-      #   Lotus::Model.configuration.migration_directory
+      #   Lotus::Model.configuration.migrations_directory
       #     # => 'db/migrations'
       #
       #   Lotus::Model.configure do
-      #     migration_directory 'my_custom/migrations'
+      #     migrations_directory 'my_custom/migrations'
       #   end
       #
-      #   Lotus::Model.configuration.migration_directory
+      #   Lotus::Model.configuration.migrations_directory
       #     # => 'my_custom/migrations'
       #
       # @since 0.3.0
       # @see Lotus::Model.configure
-      def migration_directory(directory=nil)
+      def migrations_directory(directory=nil)
         if directory.nil?
-          @migration_directory ||= _default_migration_directory
+          @migrations_directory ||= _default_migrations_directory
         else
-          @migration_directory = directory
+          @migrations_directory = directory
         end
       end
 
@@ -250,7 +250,7 @@ module Lotus
           c.instance_variable_set(:@adapter, @adapter)
           c.instance_variable_set(:@mapper, @mapper)
           c.instance_variable_set(:@logger, @logger)
-          c.instance_variable_set(:@migration_directory, @migration_directory)
+          c.instance_variable_set(:@migrations_directory, @migrations_directory)
         end
       end
 
@@ -285,7 +285,7 @@ module Lotus
       #
       # @since 0.3.0
       # @api private
-      def _default_migration_directory
+      def _default_migrations_directory
         Pathname.pwd.join('db', 'migrations')
       end
 

--- a/lib/lotus/model/migration.rb
+++ b/lib/lotus/model/migration.rb
@@ -1,0 +1,128 @@
+require 'delegate'
+require 'lotus/utils/class_attribute'
+require 'lotus/model/adapters/sql/schema_modifier'
+
+module Lotus
+  module Model
+    # Allow users to easily group schema changes and migrate the
+    # database to a newer version or revert to a previous version.
+    #
+    # A migration class must be subclass of Lotus::Model::Migration
+    # and must implement 2 instance methods:
+    #
+    #   * up   - to migrate
+    #   * down - to rollback
+    #
+    # Both instance methods could access following schema modification methods.
+    # Please consult +Lotus::Model::Adapters::Sql::SchemaModifier+ for more details.
+    #
+    # To apply up/down migration, please consult +Lotus::Model::Migration.apply+
+    # though it is not recommended to apply migration directly without going
+    # through the +Lotus::Model::Migrator#run+. Because Migrator will retain
+    # the history of applied migrations.
+    #
+    # The implementation is based on top of old Sequel::Migration.
+    #
+    # @example Create and apply migration
+    #   require 'lotus/model/migration'
+    #
+    #   class MyMigration < Lotus::Model::Migration
+    #     def up
+    #       create_table(:authors) do
+    #         primary_key :id
+    #         String :name
+    #       end
+    #     end
+    #
+    #     def down
+    #       drop_table(:authors)
+    #     end
+    #   end
+    #
+    #   # to apply up migration
+    #   MyMigration.new(adapter).up
+    #
+    #   # to apply down migration
+    #   MyMigration.new(adapter).down
+    #
+    # @since x.x.x
+    # @see Lotus::Model::Adapters::Sql::SchemaModifier
+    # @api private
+    class Migration < SimpleDelegator
+      # Delegate all schema modification methods to +Lotus::Model::Adapters::Sql::SchemaModifier+
+      #
+      # @param [Lotus::Model::Adapters::SqlAdapter] instance of SQL adapter
+      # @param [Logger] instance of logger for adapter connection
+      #
+      # @since x.x.x
+      def initialize(adapter, logger = nil)
+        @schema_modifier = Lotus::Model::Adapters::Sql::SchemaModifier.new(adapter, logger)
+        super(@schema_modifier)
+      end
+
+      class << self
+        # Applies the migration to the supplied database in the specified
+        # direction.
+        #
+        # @param [Lotus::Model::Adapters::SqlAdapter] instance of SQL adapter
+        # @param [Logger] instance of logger for adapter connection
+        # @param [Symbol] direction, either :up or :down
+        #
+        # @since x.x.x
+        def apply(adapter, direction, logger = nil)
+          _validate_direction(direction)
+          new(adapter, logger).send(direction)
+        end
+
+        # Don't allow transaction overriding in old migrations.
+        def use_transactions
+          nil
+        end
+
+        private
+
+        # Validate the direction
+        #
+        # @since x.x.x
+        # @api private
+        def _validate_direction(direction)
+          raise(ArgumentError, "Invalid migration direction specified (#{direction.inspect})") unless [:up, :down].include?(direction)
+        end
+      end
+
+      include Utils::ClassAttribute
+
+      # It's used to store all subclasses of Migration
+      #
+      # @since x.x.x
+      # @api private
+      class_attribute :descendants
+      self.descendants ||= []
+
+      # Adds the new migration class to the list of Migration descendants.
+      #
+      # @since x.x.x
+      # @see Lotus::Model::Migration.descendants
+      def self.inherited(base)
+        descendants << base
+      end
+
+      # The default up action does nothing
+      # It's supposed to be overriden by subclass
+      #
+      # @since x.x.x
+      def up
+        raise NotImplementedError.new("Please override this method in migration subclass")
+      end
+
+      # The default down action does nothing
+      # It's supposed to be overriden by subclass
+      #
+      # @since x.x.x
+      def down
+        raise NotImplementedError.new("Please override this method in migration subclass")
+      end
+
+    end
+  end
+end

--- a/lib/lotus/model/migration/file.rb
+++ b/lib/lotus/model/migration/file.rb
@@ -1,0 +1,52 @@
+module Lotus
+  module Model
+    class Migration
+      # This class represents the migration file object
+      #
+      # @since x.x.x
+      # @api private
+      class File < ::File
+        # The timestamp migration file naming pattern
+        # Migration file follows format:
+        #
+        # <yyyymmddhhmmss>_<title>.rb
+        #
+        # @since x.x.x
+        MIGRATION_FILE_PATTERN = /\A(\d{14})_.+\.rb\z/i.freeze
+
+        # Returns the version of the migration file
+        #
+        # @since x.x.x
+        attr_reader :version
+
+        def initialize(*)
+          super
+          @version = _get_version_from_filename(self.path)
+        end
+
+        # Check if file is migration file
+        #
+        # @param [String] filename
+        # @example Filename that comply with timestamp migration format
+        #   filename = '20150122124515_create_posts.rb'
+        #   Lotus::Model::Migration::File.migration_file?(filename)
+        #   # => true
+        #
+        # @since x.x.x
+        def self.migration_file?(filename)
+          !!MIGRATION_FILE_PATTERN.match(filename)
+        end
+
+        private
+
+        # Extract version from filename
+        #
+        # @api private
+        # @since x.x.x
+        def _get_version_from_filename(filename)
+          MIGRATION_FILE_PATTERN.match(File.basename(filename))[1].to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/model/migrator.rb
+++ b/lib/lotus/model/migrator.rb
@@ -123,13 +123,13 @@ module Lotus
         _check_if_adapter_support_migration
 
         @adapter = _get_adapter
-        @db = adapter.instance_variable_get(:@connection)
+        @db = adapter.connection
         @logger = _get_logger
         @directory = _get_migrations_directory
         @allow_missing_migration_files = opts[:allow_missing_migration_files]
         @files = _get_migration_files
         @column = SCHEMA_COLUMN
-        schema, table = @db.send(:schema_and_table, SCHEMA_TABLE)
+        schema, table = @db.schema_and_table(SCHEMA_TABLE)
         @table = schema ? Sequel::SQL::QualifiedIdentifier.new(schema, table) : table
         @ds = schema_dataset
         @use_transactions = opts[:use_transactions]

--- a/lib/lotus/model/migrator.rb
+++ b/lib/lotus/model/migrator.rb
@@ -1,0 +1,544 @@
+require 'sequel'
+require 'lotus/model/migration'
+require 'lotus/model/migration/file'
+
+module Lotus
+  module Model
+    # The +Migrator+ class performs migrations/rollingback on a folder
+    # with migration files that comply with timestamp format:
+    #
+    #   <yyyymmddhhmmss>_<title>.rb
+    #
+    # For example:
+    #
+    #   20150122124517_create_users.rb
+    #
+    # Please be noted that timestamp must be unique.
+    #
+    # The migration file must extend +Lotus::Model::Migration+ and
+    # implement +up+ and +down+ methods.
+    # @see Lotus::Model::Migration
+    #
+    # Migrator reads the model configuration for SQL adapter connection,
+    # migration files and optional logger (default to nil).
+    # @see Lotus::Model::Configuration#adapter
+    # @see Lotus::Model::Configuration#migration_directory
+    # @see Lotus::Model::Configuration#logging
+    #
+    # @example Configure model framework
+    #   Lotus::Model.configure do
+    #     logging ::Logger.new(STDOUT)
+    #     migration_directory 'db/migrations'
+    #     adapter type: :sql, uri: 'sqlite3://localhost/database'
+    #   end
+    #
+    # To apply a migrator in either up or down direction, the model configuration
+    # must be configured before the constuctor instantiated the object.
+    # Method +run+ takes current version and target version and migrate
+    # the migrations accordingly.
+    #
+    # If no current version is supplied, it is read from the database.
+    # The migrator automatically create schema_migration table to
+    # keep track of current migration version. If no migration is
+    # stored in the database, the version is considered to be 0.
+    # if no target version is specified, the database is migrated
+    # to the latest version available in migration directory.
+    #
+    # The implementation borrows much code from Sequel::Migrator.
+    #
+    # @example Migrate all migrations in db/migrations to latest
+    #   require 'lotus/model'
+    #   require 'lotus/model/migrator'
+    #
+    #   Lotus::Model.configure do
+    #     adapter type: :sql, uri: 'sqlite3://localhost/database'
+    #   end
+    #
+    #   Lotus::Model::Migrator.new.run
+    #
+    # @since x.x.x
+    # @see Sequel::Migration
+    class Migrator
+      # The framework configuration
+      #
+      # @since x.x.x
+      # @api private
+      include Utils::ClassAttribute
+      class_attribute :configuration
+
+      # It's raised when migration does not support the adapter
+      #
+      # @since x.x.x
+      class UnsupportedAdapterError < ::StandardError
+        def initialize(adapter_type)
+          super("Adapter #{adapter_type} is not supported")
+        end
+      end
+
+      # It's raised when adapter is not configured
+      #
+      # @since x.x.x
+      class MissingAdapterConfigurationError < ::StandardError
+        def initialize
+          super('Please configure your adapter. See Lotus::Model.configure for more details')
+        end
+      end
+
+      # It's raised when there are missing migration files
+      #
+      # @since x.x.x
+      class MissingMigrationsError < ::StandardError
+        def initialize(missing_migration_files)
+          super("Applied migration files not in file system: #{missing_migration_files.map { |f| f.path }.join(', ')}")
+        end
+      end
+
+      # Error for duplicated versions in migration files
+      # It's raised when there are duplication in versionings
+      #
+      # @since x.x.x
+      #
+      # @see Lotus::Model::Migrator#run
+      class DuplicatedVersionsError < ::StandardError
+      end
+
+      # The list of supported adapters
+      #
+      # @since x.x.x
+      SUPPORTED_ADAPTERS = [:sql].freeze
+
+      # The default column for schema migrations table
+      #
+      # @since x.x.x
+      SCHEMA_COLUMN = :version
+
+      # The default table for scheme migrations
+      #
+      # @since x.x.x
+      SCHEMA_TABLE = :schema_migrations
+
+      def initialize(opts={})
+        _copy_framework_configuration
+        _check_if_adapter_is_configured
+        _check_if_adapter_support_migration
+
+        @adapter = _get_adapter
+        @db = adapter.instance_variable_get(:@connection)
+        @logger = _get_logger
+        @directory = _get_migration_directory
+        @allow_missing_migration_files = opts[:allow_missing_migration_files]
+        @files = _get_migration_files
+        @column = SCHEMA_COLUMN
+        schema, table = @db.send(:schema_and_table, SCHEMA_TABLE)
+        @table = schema ? Sequel::SQL::QualifiedIdentifier.new(schema, table) : table
+        @ds = schema_dataset
+        @use_transactions = opts[:use_transactions]
+      end
+
+      # The timestamp migrator is current if there are no migrations to apply
+      # in either direction.
+      def is_current?
+        _get_migration_tuples.empty?
+      end
+
+      # Apply migration operation
+      #
+      # @param target [String] the target migration file
+      # @param current [String] the current migration version
+      #
+      # @since x.x.x
+      #
+      # @see Lotus::Model::Migrator#rollback
+      # @see Lotus::Model::Migrator#migrate
+      def run(current: nil, target: nil)
+        _get_migration_tuples(current: current, target: target).each do |klass, version, direction|
+          t = Time.now
+          db.log_info("Begin applying migration #{version}, direction: #{direction}")
+
+          _checked_transaction(klass) do
+            klass.apply(adapter, direction, logger)
+            _update_schema_migrations(version, direction)
+          end
+
+          db.log_info("Finished applying migration #{version}, direction: #{direction}, took #{sprintf('%0.6f', Time.now - t)} seconds")
+        end
+        nil
+      end
+
+      # Migrate migrations
+      #
+      # By default, migrate to latest migration resided in db/migrations
+      #
+      # @example Migrate to the latest migration
+      #   require 'lotus/model/migration'
+      #   adapter_cfg = Lotus::Model::Config::Adapter.new(type: :sql, uri: DATABASE_URI)
+      #   Lotus::Model::Migrator.new(adapter_cfg).migrate
+      #
+      # @since x.x.x
+      #
+      # @see Lotus::Model::Migrator#run
+      def migrate
+        run
+      end
+
+      # Rollback migrations
+      #
+      # By default, rollback 1 step from all migrations resided in db/migrations
+      #
+      # @param step [Integer] the step from the last migration that should rollback to (default: 1)
+      #
+      # @example Rollback to the previous migration
+      #   require 'lotus/model'
+      #   require 'lotus/model/migration'
+      #   require 'lotus/model/migrator'
+      #
+      #   adapter_cfg = Lotus::Model::Config::Adapter.new(type: :sql, uri: DATABASE_URI)
+      #   Lotus::Model::Migrator.new(adapter_cfg).rollback
+      #
+      # @example Rollback 2 migrations
+      #   require 'lotus/model'
+      #   require 'lotus/model/migration'
+      #   require 'lotus/model/migrator'
+      #
+      #   adapter_cfg = Lotus::Model::Config::Adapter.new(type: :sql, uri: DATABASE_URI)
+      #   Lotus::Model::Migrator.new(adapter_cfg).rollback(step: 2)
+      #
+      # @example Rollback from custom migration directory
+      #   require 'lotus/model'
+      #   require 'lotus/model/migration'
+      #   require 'lotus/model/migrator'
+      #
+      #   adapter_cfg = Lotus::Model::Config::Adapter.new(type: :sql, uri: DATABASE_URI)
+      #   Lotus::Model::Migrator.new(adapter_cfg).rollback
+      #
+      # @since x.x.x
+      #
+      # @see Lotus::Model::Migrator#run
+      def rollback(step: 1)
+        run(target: _target_version(step), current: current_version)
+      end
+
+      # Get the current schema version
+      #
+      # @since x.x.x
+      # @api private
+      def current_version
+        last_record = ds.last
+        last_record ? last_record[column].to_i : 0
+      end
+
+      private
+
+      # The DB connection instance
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :db
+
+      # The directory for this migrator's files
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :directory
+
+      # The dataset for this migrator, representing the +schema_migrations+
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :ds
+
+      # The adapter used by this migrator
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :adapter
+
+      # All applied migration files
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :files
+
+      # The logger used by database connection
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :logger
+
+      # Hold the table name of migration table
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :table
+
+      # Hold the column name of migration table
+      #
+      # @since x.x.x
+      # @api private
+      attr_reader :column
+
+      # Get the schema version before the current version
+      #
+      # @since x.x.x
+      # @api private
+      def _target_version(step)
+        record = ds.all[-(1+step)]
+        record ? record[column].to_i : 0
+      end
+
+      # Remove or update migration version
+      #
+      # @since x.x.x
+      # @api private
+      def _update_schema_migrations(version, direction)
+        if direction == :up
+          _add_to_schema_migrations(version)
+        else
+          _remove_from_schema_migrarions(version)
+        end
+      end
+
+      # Add migration version to schema table
+      #
+      # @since x.x.x
+      # @api private
+      def _add_to_schema_migrations(version)
+        ds.insert(column => version)
+      end
+
+      # Remove migration version from schema table
+      #
+      # @since x.x.x
+      # @api private
+      def _remove_from_schema_migrarions(version)
+        ds.filter(column => version).delete
+      end
+
+      # @return [Lotus::Model::Migration::File] applied migration files
+      # @since x.x.x
+      # @api private
+      def _get_applied_migrations
+        migrated_versions = _get_migration_versions
+        missing_migration_files = []
+        applied_migration_files = []
+
+        if migrated_versions.any?
+          files.each do |f|
+            if migrated_versions.include?(f.version)
+              applied_migration_files << f
+            else
+              missing_migration_files << f
+            end
+          end
+
+          if missing_migration_files.any? && !@allow_missing_migration_files
+            raise MissingMigrationsError.new(missing_migration_files)
+          end
+        end
+
+        applied_migration_files
+      end
+
+      # Return all applied migration versions
+      #
+      # @since x.x.x
+      # @api private
+      def _get_migration_versions
+        ds.select_order_map(column).map { |v| v.to_i }.sort
+      end
+
+      # Returns any migration files found in the migrator's directory
+      #
+      # @since x.x.x
+      # @api private
+      def _get_migration_files
+        files = []
+        Dir.new(directory).each do |file|
+          next unless Lotus::Model::Migration::File.migration_file?(file)
+          files << Lotus::Model::Migration::File.new(File.join(directory, file))
+        end
+
+        _validate_duplicated_versions(files)
+
+        files.sort_by { |f| f.version }
+      end
+
+      # Validate if files has any duplicated version
+      #
+      # @since x.x.x
+      # @api private
+      def _validate_duplicated_versions(files)
+        versions = files.map { |f| f.version }
+        duplicated_versions = versions.select { |v| versions.index(v) != versions.rindex(v) }.uniq
+        duplicated_version_files = files.select { |f| duplicated_versions.include?(f.version) }.group_by { |f| f.version }
+
+        if duplicated_versions.any?
+          message = ['Duplicated versions in following migrations:']
+          duplicated_version_files.each do |vesrion, files|
+            message << "  * #{files.map { |f| f.path }.join(', ')}"
+          end
+          message = message.join("\n")
+
+          raise DuplicatedVersionsError.new(message)
+        end
+      end
+
+      # Returns tuples of migration class, version, and direction
+      #
+      # @since x.x.x
+      # @api private
+      def _get_migration_tuples(current: nil, target: nil)
+        _remove_migration_classes
+        up_mts = []
+        down_mts = []
+        ms = ::Lotus::Model::Migration.descendants
+        applied_migrations = _get_applied_migrations
+
+        files.each do |file|
+          path = file.path
+          version = file.version
+          if target
+            if version > target
+              if applied_migrations.include?(file)
+                load(path)
+                down_mts << [ms.last, version, :down]
+              end
+            elsif !applied_migrations.include?(file)
+              load(path)
+              up_mts << [ms.last, version, :up]
+            end
+          elsif !applied_migrations.include?(file)
+            load(path)
+            up_mts << [ms.last, version, :up]
+          end
+        end
+        up_mts + down_mts.reverse
+      end
+
+      # Returns the dataset for the schema_migrations table. If no such table
+      # exists, it is automatically created.
+      #
+      # @since x.x.x
+      # @api private
+      def schema_dataset
+        c = column
+        ds = db.from(table).order(column)
+
+        if !db.table_exists?(table)
+          db.create_table(table) { String c, primary_key: true }
+        elsif !ds.columns.include?(c)
+          raise(Error, "Migrator table #{table} does not contain column #{c}")
+        end
+        ds
+      end
+
+      # If transactions should be used for the migration, yield to the block
+      # inside a transaction.  Otherwise, just yield to the block.
+      #
+      # @since x.x.x
+      # @api private
+      def _checked_transaction(migration, &block)
+        use_trans = if @use_transactions.nil?
+                      if migration.use_transactions.nil?
+                        @db.supports_transactional_ddl?
+                      else
+                        migration.use_transactions
+                      end
+                    else
+                      @use_transactions
+                    end
+
+        if use_trans
+          db.transaction(&block)
+        else
+          yield
+        end
+      end
+
+      # Remove all migration classes.  Done by the migrator to ensure that
+      # the correct migration classes are picked up.
+      #
+      # @since x.x.x
+      # @api private
+      def _remove_migration_classes
+        # Remove class definitions
+        ::Lotus::Model::Migration.descendants.each do |c|
+          Object.send(:remove_const, c.to_s) rescue nil
+        end
+        ::Lotus::Model::Migration.descendants.clear # remove any defined migration classes
+      end
+
+      # The framework configuration
+      # It is copied from the framework configuration in constructor
+      #
+      # @api private
+      def configuration
+        self.class.configuration
+      end
+
+      # Copy framework configuration
+      #
+      # @since x.x.x
+      # @api private
+      def _copy_framework_configuration
+        config = Lotus::Model::Configuration.for(self.class)
+        self.class.configuration = config
+      end
+
+      # Return the adapter configuration
+      #
+      # @since x.x.x
+      # @api private
+      def _adapter_config
+        configuration.adapter_config
+      end
+
+      # Check to ensure adapter is configured
+      #
+      # @since x.x.x
+      # @api private
+      def _check_if_adapter_is_configured
+        raise MissingAdapterConfigurationError unless _adapter_config
+      end
+
+      # Check if adapter supports migration
+      #
+      # @since x.x.x
+      # @api private
+      def _check_if_adapter_support_migration
+        adapter_type = _adapter_config.type
+
+        unless SUPPORTED_ADAPTERS.include?(adapter_type)
+          raise UnsupportedAdapterError.new(adapter_type)
+        end
+      end
+
+      # Instantiate adapter
+      #
+      # @since x.x.x
+      # @api private
+      def _get_adapter
+        self.class.configuration.build_adapter
+        self.class.configuration.instance_variable_get(:@adapter)
+      end
+
+      # Return the logger from framework configuration
+      #
+      # @since x.x.x
+      # @api private
+      def _get_logger
+        configuration.logger
+      end
+
+      # Get the migration directory
+      #
+      # @since x.x.x
+      # @api private
+      def _get_migration_directory
+        directory = configuration.migration_directory
+        raise(Error, "Must supply a valid migration path") unless File.directory?(directory)
+        directory
+      end
+    end
+  end
+end

--- a/lib/lotus/model/migrator.rb
+++ b/lib/lotus/model/migrator.rb
@@ -22,13 +22,13 @@ module Lotus
     # Migrator reads the model configuration for SQL adapter connection,
     # migration files and optional logger (default to nil).
     # @see Lotus::Model::Configuration#adapter
-    # @see Lotus::Model::Configuration#migration_directory
+    # @see Lotus::Model::Configuration#migrations_directory
     # @see Lotus::Model::Configuration#logging
     #
     # @example Configure model framework
     #   Lotus::Model.configure do
     #     logging ::Logger.new(STDOUT)
-    #     migration_directory 'db/migrations'
+    #     migrations_directory 'db/migrations'
     #     adapter type: :sql, uri: 'sqlite3://localhost/database'
     #   end
     #
@@ -125,7 +125,7 @@ module Lotus
         @adapter = _get_adapter
         @db = adapter.instance_variable_get(:@connection)
         @logger = _get_logger
-        @directory = _get_migration_directory
+        @directory = _get_migrations_directory
         @allow_missing_migration_files = opts[:allow_missing_migration_files]
         @files = _get_migration_files
         @column = SCHEMA_COLUMN
@@ -534,8 +534,8 @@ module Lotus
       #
       # @since x.x.x
       # @api private
-      def _get_migration_directory
-        directory = configuration.migration_directory
+      def _get_migrations_directory
+        directory = configuration.migrations_directory
         raise(Error, "Must supply a valid migration path") unless File.directory?(directory)
         directory
       end

--- a/test/fixtures/duplicated_migrations/20150222124516_create_comments.rb
+++ b/test/fixtures/duplicated_migrations/20150222124516_create_comments.rb
@@ -1,0 +1,12 @@
+class CreateComments < Lotus::Model::Migration
+  def up
+    create_table :comments do
+      primary_key :id
+      String :content
+    end
+  end
+
+  def down
+    drop_table :comments
+  end
+end

--- a/test/fixtures/duplicated_migrations/20150222124516_remove_comments.rb
+++ b/test/fixtures/duplicated_migrations/20150222124516_remove_comments.rb
@@ -1,0 +1,12 @@
+class RemoveComments < Lotus::Model::Migration
+  def up
+    drop_table :comments
+  end
+
+  def down
+    create_table :comments do
+      primary_key :id
+      String :content
+    end
+  end
+end

--- a/test/fixtures/migrations/20150122124515_create_posts.rb
+++ b/test/fixtures/migrations/20150122124515_create_posts.rb
@@ -1,0 +1,13 @@
+class CreatePosts < Lotus::Model::Migration
+  def up
+    create_table :posts do
+      primary_key :id
+      String :title
+      String :content
+    end
+  end
+
+  def down
+    drop_table :posts
+  end
+end

--- a/test/fixtures/migrations/20150222124516_create_comments.rb
+++ b/test/fixtures/migrations/20150222124516_create_comments.rb
@@ -1,0 +1,12 @@
+class CreateComments < Lotus::Model::Migration
+  def up
+    create_table :comments do
+      primary_key :id
+      String :content
+    end
+  end
+
+  def down
+    drop_table :comments
+  end
+end

--- a/test/integration/configuration_test.rb
+++ b/test/integration/configuration_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 
 describe 'Configuration DSL' do
   before do
+    Lotus::Model.unload!
+
     Lotus::Model.configure do
       adapter type: :memory, uri: 'memory://localhost'
 
@@ -17,10 +19,6 @@ describe 'Configuration DSL' do
     end
 
     Lotus::Model.load!
-  end
-
-  after do
-    Lotus::Model.unload!
   end
 
   describe 'when creating new user' do

--- a/test/integration/migration_test.rb
+++ b/test/integration/migration_test.rb
@@ -1,0 +1,90 @@
+require 'test_helper'
+require 'lotus/model/migration'
+require 'lotus/model/migrator'
+
+describe 'SQL adapter migration' do
+  let(:migrator) do
+    Lotus::Model.configuration.reset!
+    Lotus::Model.configure do
+      migration_directory 'test/fixtures/migrations'
+      adapter type: :sql, uri: SQLITE_CONNECTION_STRING
+      logger ::Logger.new('/dev/null') # silence the output in test
+    end
+
+    Lotus::Model::Migrator.new
+  end
+  let(:db) { migrator.send(:db) }
+
+  before do
+    db.execute('DELETE FROM schema_migrations') if db.table_exists?(:schema_migrations)
+    db.drop_table(:posts)    if db.table_exists?(:posts)
+    db.drop_table(:comments) if db.table_exists?(:comments)
+  end
+
+  describe 'when there are migrations with duplicated versions' do
+    it 'raises error' do
+      Lotus::Model.configuration.migration_directory('test/fixtures/duplicated_migrations')
+      expected = ["Duplicated versions in following migrations:"]
+      expected << "  * test/fixtures/duplicated_migrations/20150222124516_create_comments.rb, test/fixtures/duplicated_migrations/20150222124516_remove_comments.rb"
+      expected = expected.join("\n")
+      exception = -> { Lotus::Model::Migrator.new }.must_raise(Lotus::Model::Migrator::DuplicatedVersionsError)
+      exception.message.must_equal(expected)
+    end
+  end
+
+  describe 'when there are missing migrations' do
+    before do
+      db[:schema_migrations].insert({
+        :version => '20150122124514',
+        :version => '20150222124515'
+      })
+    end
+
+    it 'raises error when migrate' do
+      exception = -> { migrator.migrate }.must_raise(Lotus::Model::Migrator::MissingMigrationsError)
+      exception.message.must_equal "Applied migration files not in file system: test/fixtures/migrations/20150122124515_create_posts.rb, test/fixtures/migrations/20150222124516_create_comments.rb"
+    end
+  end
+
+  describe 'when migrate to latest versions' do
+    before do
+      migrator.migrate
+    end
+
+    it 'applies all up migrations correctly' do
+      db.table_exists?(:posts).must_equal true
+      db.table_exists?(:comments).must_equal true
+      db.from(:posts).columns.must_equal [:id, :title, :content]
+      db.from(:comments).columns.must_equal [:id, :content]
+      db.from(:schema_migrations).all.map { |row| row[:version] }.must_equal ['20150122124515', '20150222124516']
+    end
+  end
+
+  describe 'when roll back to the previous migration' do
+    before do
+      migrator.migrate
+      migrator.rollback
+    end
+
+    it 'applies all down migrations correctly' do
+      db.table_exists?(:comments).must_equal false
+      db.table_exists?(:posts).must_equal true
+
+      db.from(:schema_migrations).all.map { |row| row[:version] }.must_equal ['20150122124515']
+    end
+  end
+
+  describe 'when rolling back with specfied steps' do
+    before do
+      migrator.migrate
+      migrator.rollback(step: 2)
+    end
+
+    it 'applies all down migrations correctly' do
+      db.table_exists?(:comments).must_equal false
+      db.table_exists?(:posts).must_equal false
+
+      db.from(:schema_migrations).all.map { |row| row[:filename] }.must_equal []
+    end
+  end
+end

--- a/test/integration/migration_test.rb
+++ b/test/integration/migration_test.rb
@@ -6,7 +6,7 @@ describe 'SQL adapter migration' do
   let(:migrator) do
     Lotus::Model.configuration.reset!
     Lotus::Model.configure do
-      migration_directory 'test/fixtures/migrations'
+      migrations_directory 'test/fixtures/migrations'
       adapter type: :sql, uri: SQLITE_CONNECTION_STRING
       logger ::Logger.new('/dev/null') # silence the output in test
     end
@@ -23,7 +23,7 @@ describe 'SQL adapter migration' do
 
   describe 'when there are migrations with duplicated versions' do
     it 'raises error' do
-      Lotus::Model.configuration.migration_directory('test/fixtures/duplicated_migrations')
+      Lotus::Model.configuration.migrations_directory('test/fixtures/duplicated_migrations')
       expected = ["Duplicated versions in following migrations:"]
       expected << "  * test/fixtures/duplicated_migrations/20150222124516_create_comments.rb, test/fixtures/duplicated_migrations/20150222124516_remove_comments.rb"
       expected = expected.join("\n")

--- a/test/model/configuration_test.rb
+++ b/test/model/configuration_test.rb
@@ -182,19 +182,19 @@ describe Lotus::Model::Configuration do
     end
   end
 
-  describe '#migration_directory' do
+  describe '#migrations_directory' do
     describe "when no migration directory has been pre-configured before" do
       it 'returns default directory' do
         configuration.reset!
-        configuration.migration_directory.must_equal configuration.send(:_default_migration_directory)
+        configuration.migrations_directory.must_equal configuration.send(:_default_migrations_directory)
       end
     end
 
     describe "when migration directory is provided" do
       it 'returns default directory' do
         directory = 'custom/db/migrations'
-        configuration.migration_directory directory
-        configuration.migration_directory.must_equal directory
+        configuration.migrations_directory directory
+        configuration.migrations_directory.must_equal directory
       end
     end
   end

--- a/test/model/configuration_test.rb
+++ b/test/model/configuration_test.rb
@@ -3,6 +3,40 @@ require 'test_helper'
 describe Lotus::Model::Configuration do
   let(:configuration) { Lotus::Model::Configuration.new }
 
+  describe '.for' do
+    before do
+      Lotus::Model.configure do
+        adapter type: :memory, uri: 'memory://localhost'
+      end
+
+      module Lotus
+        class Zen
+        end
+      end
+
+      class Zen
+        Model = ::Lotus::Model.duplicate(self) {}
+        class Sencha; end
+      end
+    end
+
+    after do
+      Object.send(:remove_const, :Zen)
+    end
+
+    describe 'when base class has Lotus namespace' do
+      it 'returns duplicated configuration of Lotus::Model' do
+        Lotus::Model::Configuration.for(Lotus::Zen).must_equal Lotus::Model.configuration
+      end
+    end
+
+    describe 'when base class has namespace' do
+      it 'returns duplicated configuration of {namespace}::Model' do
+        Lotus::Model::Configuration.for(Zen::Sencha).must_equal Zen::Model.configuration
+      end
+    end
+  end
+
   describe '#adapter_config' do
     it 'defaults to an empty set' do
       configuration.adapter_config.must_be_nil
@@ -120,6 +154,47 @@ describe Lotus::Model::Configuration do
       it 'raise error' do
         exception = -> { configuration.mapping }.must_raise Lotus::Model::InvalidMappingError
         exception.message.must_equal 'You must specify a block or a file.'
+      end
+    end
+  end
+
+  describe '#logger' do
+    describe "when a logger is not set" do
+      it 'default to stdlib logger' do
+        configuration.logger.must_be_instance_of ::Logger
+      end
+    end
+
+    describe "when a logger instance is given" do
+      before do
+        class CustomLogger < ::Logger
+        end
+      end
+
+      after do
+        Object.send(:remove_const, :CustomLogger)
+      end
+
+      it 'sets the logger for configuration' do
+        configuration.logger(CustomLogger.new(STDERR)).must_be_instance_of CustomLogger
+        configuration.logger.must_be_instance_of CustomLogger
+      end
+    end
+  end
+
+  describe '#migration_directory' do
+    describe "when no migration directory has been pre-configured before" do
+      it 'returns default directory' do
+        configuration.reset!
+        configuration.migration_directory.must_equal configuration.send(:_default_migration_directory)
+      end
+    end
+
+    describe "when migration directory is provided" do
+      it 'returns default directory' do
+        directory = 'custom/db/migrations'
+        configuration.migration_directory directory
+        configuration.migration_directory.must_equal directory
       end
     end
   end

--- a/test/model/migrator_test.rb
+++ b/test/model/migrator_test.rb
@@ -1,0 +1,64 @@
+require 'test_helper'
+require 'lotus/model/migrator'
+
+describe Lotus::Model::Migrator do
+  describe '#initialize' do
+    describe 'when adapter is not SQL' do
+      it 'raises error' do
+        Lotus::Model.configuration.reset!
+        Lotus::Model.configure do
+          adapter type: :memory, uri: nil
+          logger ::Logger.new('/dev/null')
+        end
+        exception = -> { Lotus::Model::Migrator.new }.must_raise Lotus::Model::Migrator::UnsupportedAdapterError
+        exception.message.must_equal 'Adapter memory is not supported'
+      end
+    end
+
+    describe 'when adapter is configured' do
+      it 'raises error' do
+        Lotus::Model.configuration.reset!
+        exception = -> { Lotus::Model::Migrator.new }.must_raise Lotus::Model::Migrator::MissingAdapterConfigurationError
+        exception.message.must_equal 'Please configure your adapter. See Lotus::Model.configure for more details'
+      end
+    end
+  end
+
+  describe '#current_version' do
+    let(:migrator) do
+      Lotus::Model.configuration.reset!
+      Lotus::Model.configure do
+        migration_directory 'test/fixtures/migrations'
+        adapter type: :sql, uri: SQLITE_CONNECTION_STRING
+        logger ::Logger.new('/dev/null')
+      end
+      Lotus::Model::Migrator.new
+    end
+
+    let(:db) { migrator.send(:db) }
+
+    before do
+      db.execute('DELETE FROM schema_migrations') if db.table_exists?(:schema_migrations)
+    end
+
+    describe 'when there is no records in schema_migrations table' do
+      it 'returns 0' do
+        migrator.current_version.must_equal 0
+      end
+    end
+
+    describe 'when there are records in schema_migrations table' do
+      before do
+        db[:schema_migrations].insert({
+          :version => '20150122124515',
+          :version => '20150222124516'
+        })
+      end
+
+      it 'returns the latest version ordered by filename version' do
+        migrator.current_version.must_equal 20150222124516
+      end
+    end
+  end
+
+end

--- a/test/model/migrator_test.rb
+++ b/test/model/migrator_test.rb
@@ -28,7 +28,7 @@ describe Lotus::Model::Migrator do
     let(:migrator) do
       Lotus::Model.configuration.reset!
       Lotus::Model.configure do
-        migration_directory 'test/fixtures/migrations'
+        migrations_directory 'test/fixtures/migrations'
         adapter type: :sql, uri: SQLITE_CONNECTION_STRING
         logger ::Logger.new('/dev/null')
       end


### PR DESCRIPTION
[Fixes #115]

This adds the basic migration feature for Lotus.

Please be noted that this PR does not cover load/dump schema.rb, I am going to have a separate PR for that.

## TODO

- [X] Migration class
- [X] Timestamp Migrator (Noted: this is totally different to Sequel::TimestampMigrator)
- [ ] Schema.rb dump
- [ ] Write CLI task 'lotus generate migration' to generate new migration
- [ ] Write CLI task 'lotus db migrate' to migrate
- [ ] Write CLI task 'lotus db rollback' to rollback
- [ ] Write CLI task 'lotus db apply' to merge all changes to schema.rb and remove migration files


## Migration

It purely base on Sequel::Migration and thus share the same interface as Sequel::Migration:

```ruby
class MyMigration < Lotus::Model::Migration
  def up
  end

  def down
  end
end
```

Migration files are located inside `LOTUS_ROOT/db/migrations` folder by default. However you can configure it with `Lotus::Model::Configuration#migration_directory`

## Migrator

To migrate, we use Migrator:

```ruby
require 'lotus/model'
require 'lotus/model/migrator'

#adapter configuration is copied from the framework configuration
# so make sure you have to configure framework first or else
# you will get error!    
Lotus::Model.configure do
  migration_directory 'my_apps/db/migrations'
  adapter type: :sql, uri: 'sqlite3://localhost/database'
end
    
Lotus::Model::Migrator.new.run
```

To migrate from a directory

```ruby
Lotus::Model::Migrator.new.migrate
```

To rollback to previous migration

```ruby
Lotus::Model::Migrator.new.rollback
```

or migration 4 steps from the last version

```ruby
Lotus::Model::Migrator.new.rollback(step: 4)
```

Furthermore, I also introduce the ability to set logger for the framework. Please see `Lotus::Model::Configuration#logging`. The migrator will use the framework logger implicitly.

## Schema Modification API

### create_table

Use to create new table. Syntax to add new column is below:

```ruby
create_table(:songs) do
  column :id, primary_key: true
  column :title, :string, null: false
  column :artist, :string, 'VARCHAR(15)'
end
```

