### PR TITLE
Fix entity class resolving in Coercer#from_record

### DIFF
--- a/lib/lotus/model/mapping/coercer.rb
+++ b/lib/lotus/model/mapping/coercer.rb
@@ -65,7 +65,7 @@ module Lotus
             end
 
             def from_record(record)
-              #{ @collection.entity }.new(
+              ::#{ @collection.entity }.new(
                 Hash[#{ @collection.attributes.map{|name,(klass,mapped)| ":#{name},Lotus::Model::Mapping::Coercions.#{klass}(record[:#{mapped}])"}.join(',') }]
               )
             end
@@ -77,4 +77,3 @@ module Lotus
     end
   end
 end
-

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -8,6 +8,11 @@ class Article
   attributes :user_id, :unmapped_attribute, :title, :comments_count
 end
 
+class Repository
+  include Lotus::Entity
+  attributes :id, :name
+end
+
 class CustomUserRepository
   include Lotus::Repository
 end

--- a/test/model/mapping/coercer_test.rb
+++ b/test/model/mapping/coercer_test.rb
@@ -24,4 +24,16 @@ describe Lotus::Model::Mapping::Coercer do
       end
     end
   end
+  
+  describe '#from_record' do
+    before do
+      collection.entity(::Repository)
+      collection.attribute :id,   Integer
+      collection.attribute :name, String
+    end
+    
+    it 'should use the correct entity class' do
+      coercer.from_record(name: 'production').class.must_equal(::Repository)
+    end
+  end
 end


### PR DESCRIPTION
Currently when the name of the entity class clashes with some constant inside `Lotus` namespace the coercer's `from_record` method uses the latter to instantiate a new entity object.

Here's a simple example:

``` ruby
collection :environments do
  entity     ::Environment
  repository ::EnvironmentRepository
  
  attribute :id,   Integer
  attribute :name, String
end

class Environment
  include Lotus::Entity
  attributes :id, :name
end

EnvironmentRepository.first
# => #<Lotus::Environment:0x007fb6e2d53b58
```

The problem lies within instance_eval: the constant inside `@collection.entity` is correct but `instance_eval` evals it inside the `Lotus` namespace so in case of clashes the constant from `Lotus` wins. Prefixing it with double-colon forces `instance_eval` to look for the constant outside.

Feel free to refactor if something is not alright.