### PR TITLE
Do not define top-level Boolean, because it is already defined in Utils

### DIFF
--- a/lib/lotus/model/mapping/collection.rb
+++ b/lib/lotus/model/mapping/collection.rb
@@ -35,25 +35,6 @@ module Lotus
         # @see Lotus::Repository
         REPOSITORY_SUFFIX = 'Repository'.freeze
 
-        # Defines top level constant for attribute usage.
-        #
-        # @since 0.1.0
-        #
-        # @see Lotus::Model::Mapping::Collection#attribute
-        #
-        # @example
-        #   require 'lotus/model'
-        #
-        #   mapper = Lotus::Model::Mapper.new do
-        #     collection :articles do
-        #       entity Article
-        #
-        #       attribute :published, Boolean
-        #     end
-        #   end
-        class ::Boolean
-        end
-
         # @attr_reader name [Symbol] the name of the collection
         #
         # @since 0.1.0

--- a/test/model/mapping/collection_test.rb
+++ b/test/model/mapping/collection_test.rb
@@ -5,12 +5,6 @@ describe Lotus::Model::Mapping::Collection do
     @collection = Lotus::Model::Mapping::Collection.new(:users, Lotus::Model::Mapping::Coercer)
   end
 
-  describe '::Boolean' do
-    it 'defines top level constant' do
-      assert defined?(::Boolean)
-    end
-  end
-
   describe '#initialize' do
     it 'assigns the name' do
       @collection.name.must_equal :users


### PR DESCRIPTION
I suggest to remove defining the top-level `Boolean` class, since this is already done in [lotus-utils](https://github.com/lotus/utils/commit/139c4d53dbd4914f79187a167c11dd62021b8966), which is a hard dependency of lotus-model.

Having two definitions of `Boolean`
- is surprising
- might lead to surprising behaviour, if they somehow have different implementations
