### PR TITLE
Ensure Array coercion to preserve data structure

### DIFF
--- a/lib/lotus/model/mapping/coercions.rb
+++ b/lib/lotus/model/mapping/coercions.rb
@@ -17,9 +17,9 @@ module Lotus
         #
         # @since 0.1.1
         #
-        # @see http://rdoc.info/gems/lotus-utils/Lotus/Utils/Kernel#Array-class_method
+        # @see http://ruby-doc.org/core/Kernel.html#method-i-Array
         def self.Array(arg)
-          Utils::Kernel.Array(arg) unless arg.nil?
+          ::Kernel.Array(arg) unless arg.nil?
         end
 
         # Coerce into a Boolean, unless the argument is nil

--- a/test/model/mapping/coercions_test.rb
+++ b/test/model/mapping/coercions_test.rb
@@ -11,6 +11,11 @@ describe Lotus::Model::Mapping::Coercions do
       actual = Lotus::Model::Mapping::Coercions.Array(nil)
       actual.must_be_nil
     end
+
+    it 'preserves data structure' do
+      actual = Lotus::Model::Mapping::Coercions.Array(expected = [['lotus-controller', '~> 0.4'], ['lotus-view', '~> 0.4']])
+      actual.must_equal expected
+    end
   end
 
   describe '.Boolean' do


### PR DESCRIPTION
### Bug

```ruby
book = Book.new(prices: [['dollar', '100'], ['euro', '100']])
book = BookRepository.create(book)

book.prices # => ["dollar", "100", "euro"]
```

### Expected behavior

```ruby
book.prices # => [["dollar","100"], ["euro", "100"]]
```