### PR TITLE
Enhance "where" condition for memory adapter

### DIFF
--- a/lib/lotus/model/adapters/memory/query.rb
+++ b/lib/lotus/model/adapters/memory/query.rb
@@ -100,7 +100,17 @@ module Lotus
           #        .where(framework: 'lotus')
           def where(condition)
             column, value = _expand_condition(condition)
-            conditions.push([:where, Proc.new{ find_all{|r| r.fetch(column, nil) == value} }])
+            conditions.push([:where, Proc.new{
+              find_all{|r|
+                case value
+                when Array,Set,Range
+                  value.include?(r.fetch(column, nil))
+                else
+                  r.fetch(column, nil) == value
+                end
+              }
+            }])
+
             self
           end
 
@@ -523,7 +533,7 @@ module Lotus
           end
 
           def _expand_condition(condition)
-            Array(condition).flatten
+            Array(condition).flatten(1)
           end
         end
       end

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -324,6 +324,39 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           result = @adapter.query(collection, &query).all
           result.must_equal [@user3]
         end
+
+        it 'accepts an array as condition' do
+          names = [@user1.name, @user2.name]
+
+          query = Proc.new {
+            where(name: names)
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user1, @user2]
+        end
+
+        it 'accepts a set as condition' do
+          names = Set.new([@user1.name, @user2.name])
+
+          query = Proc.new {
+            where(name: names)
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user1, @user2]
+        end
+
+        it 'accepts a range as condition' do
+          ages = @user3.age..@user2.age
+
+          query = Proc.new {
+            where(age: ages)
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user2, @user3]
+        end
       end
     end
 


### PR DESCRIPTION
The current implementation wasn't reflecting the functionality advertised in the API docs.
With this PR, memory adapter is able to accept `Array`, `Set` and `Range` as values.

```ruby
class BookRepository
  include Lotus::Repository

  def self.by_publication_years(years)
    query do
      where(publication_year: years)
    end
  end
end

BookRepository.by_publication_years(1999)         # exactly 1999
BookRepository.by_publication_years([1999, 2009]) # only published in 1999 and 2009
BookRepository.by_publication_years(1999..2009)   # published between 1999 and 2009
```