### PR TITLE
[WIP] Add block conditions to where on memory adapter

### DIFF
--- a/lib/lotus/model.rb
+++ b/lib/lotus/model.rb
@@ -30,11 +30,8 @@ module Lotus
     # Error for invalid query
     # It's raised when a query is malformed
     #
-    # @since 0.3.1
+    # @since x.x.x
     class InvalidQueryError < ::StandardError
-      def initialize(message = nil)
-        super(message || "There was an error with your query.")
-      end
     end
 
     include Utils::ClassAttribute

--- a/lib/lotus/model.rb
+++ b/lib/lotus/model.rb
@@ -27,6 +27,16 @@ module Lotus
     class InvalidMappingError < ::StandardError
     end
 
+    # Error for invalid query
+    # It's raised when a query is malformed
+    #
+    # @since 0.3.1
+    class InvalidQueryError < ::StandardError
+      def initialize(message = nil)
+        super(message || "There was an error with your query.")
+      end
+    end
+
     include Utils::ClassAttribute
 
     # Framework configuration

--- a/lib/lotus/model/adapters/memory/query.rb
+++ b/lib/lotus/model/adapters/memory/query.rb
@@ -575,7 +575,9 @@ module Lotus
                 begin
                   OpenStruct.new(r).instance_eval(&blk)
                 rescue
-                  raise Lotus::Model::InvalidQueryError
+                  # TODO improve this error message, informing which
+                  # attributes are invalid
+                  raise Lotus::Model::InvalidQueryError.new("Invalid query")
                 end
               }
             }])

--- a/lib/lotus/model/adapters/memory/query.rb
+++ b/lib/lotus/model/adapters/memory/query.rb
@@ -119,7 +119,7 @@ module Lotus
             elsif condition
               _push_to_expanded_condition(:where, condition) do |column, value|
                 Proc.new {
-                  find_all{ |r|
+                  find_all { |r|
                     case value
                     when Array,Set,Range
                       value.include?(r.fetch(column, nil))
@@ -166,7 +166,7 @@ module Lotus
               _push_evaluated_block_condition(:or, blk)
             elsif condition
               _push_to_expanded_condition(:or, condition) do |column, value|
-                Proc.new { find_all{ |r| r.fetch(column) == value} }
+                Proc.new { find_all { |r| r.fetch(column) == value} }
               end
             end
 

--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -70,9 +70,14 @@ module Lotus
           #
           # @return [Array] a collection of entities
           #
+          # @raise [Lotus::Model::InvalidQueryError] if there is some issue when
+          # hitting the database for fetching records
+          #
           # @since 0.1.0
           def all
             Lotus::Utils::Kernel.Array(run)
+          rescue Sequel::DatabaseError => e
+            raise Lotus::Model::InvalidQueryError.new(e.message)
           end
 
           # Adds a SQL `WHERE` condition.

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -367,6 +367,16 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           result.must_equal [@user1]
         end
 
+        it "raises InvalidQueryError when columns are invalid in expression" do
+          query  = Proc.new {
+            where { a > 32 }
+          }
+
+          -> {
+            @adapter.query(collection, &query).all
+          }.must_raise(Lotus::Model::InvalidQueryError)
+        end
+
         it "accepts nested block conditions" do
           query  = Proc.new {
             where { age > 31 }.where { name == 'L' }
@@ -441,6 +451,43 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           result = @adapter.query(collection, &query).all
           result.must_equal [@user3]
         end
+
+        it 'accepts a block as condition' do
+          query  = Proc.new {
+            exclude{ age > 31 }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user2, @user3]
+        end
+
+        it "raises InvalidQueryError when columns are invalid in expression" do
+          query  = Proc.new {
+            exclude { a > 32 }
+          }
+
+          -> {
+            @adapter.query(collection, &query).all
+          }.must_raise(Lotus::Model::InvalidQueryError)
+        end
+
+        it "accepts nested block conditions" do
+          query  = Proc.new {
+            exclude { age > 31 }.exclude { name == 'MG' }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user3]
+        end
+
+        it "takes into account both hash and block conditions" do
+          query  = Proc.new {
+            exclude(age: 32).exclude { name == 'MG' }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user3]
+        end
       end
     end
 
@@ -459,6 +506,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         before do
           @user1 = @adapter.create(collection, user1)
           @user2 = @adapter.create(collection, user2)
+          @user3 = @adapter.create(collection, user3)
         end
 
         it 'returns selected records' do
@@ -482,6 +530,43 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
           result = @adapter.query(collection, &query).all
           result.must_equal [@user2]
+        end
+
+        it 'accepts a block as condition' do
+          query  = Proc.new {
+            where(name: "MG").or { age > 31 }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user2, @user1]
+        end
+
+        it "raises InvalidQueryError when columns are invalid in expression" do
+          query  = Proc.new {
+            where(name: "MG").or { a > 31 }
+          }
+
+          -> {
+            @adapter.query(collection, &query).all
+          }.must_raise(Lotus::Model::InvalidQueryError)
+        end
+
+        it "accepts nested block conditions" do
+          query  = Proc.new {
+            where { name == "L" }.or { name == 'MG' }.or { name == "JS" }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user1, @user2, @user3]
+        end
+
+        it "takes into account both hash and block conditions" do
+          query  = Proc.new {
+            where(age: 32).or { name == 'MG' }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user1, @user2]
         end
       end
     end

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -359,7 +359,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it 'accepts a block as condition' do
-          query  = Proc.new {
+          query = Proc.new {
             where { age > 31 }
           }
 
@@ -368,17 +368,16 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it "raises InvalidQueryError when columns are invalid in expression" do
-          query  = Proc.new {
-            where { a > 32 }
-          }
-
-          -> {
+          exception = -> {
+            query = Proc.new { where { a > 32 } }
             @adapter.query(collection, &query).all
           }.must_raise(Lotus::Model::InvalidQueryError)
+
+          exception.message.must_equal "Invalid query"
         end
 
         it "accepts nested block conditions" do
-          query  = Proc.new {
+          query = Proc.new {
             where { age > 31 }.where { name == 'L' }
           }
 
@@ -387,7 +386,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it "takes into account both hash and block conditions" do
-          query  = Proc.new {
+          query = Proc.new {
             where(age: 32).where { name == 'L' }
           }
 
@@ -453,7 +452,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it 'accepts a block as condition' do
-          query  = Proc.new {
+          query = Proc.new {
             exclude { age > 31 }
           }
 
@@ -462,17 +461,16 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it "raises InvalidQueryError when columns are invalid in expression" do
-          query  = Proc.new {
-            exclude { a > 32 }
-          }
-
-          -> {
+          exception = -> {
+            query = Proc.new { exclude { a > 32 } }
             @adapter.query(collection, &query).all
           }.must_raise(Lotus::Model::InvalidQueryError)
+
+          exception.message.must_equal "Invalid query"
         end
 
         it "accepts nested block conditions" do
-          query  = Proc.new {
+          query = Proc.new {
             exclude { age > 31 }.exclude { name == 'MG' }
           }
 
@@ -481,7 +479,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it "takes into account both hash and block conditions" do
-          query  = Proc.new {
+          query = Proc.new {
             exclude(age: 32).exclude { name == 'MG' }
           }
 
@@ -533,7 +531,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it 'accepts a block as condition' do
-          query  = Proc.new {
+          query = Proc.new {
             where(name: "MG").or { age > 31 }
           }
 
@@ -542,17 +540,16 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it "raises InvalidQueryError when columns are invalid in expression" do
-          query  = Proc.new {
-            where(name: "MG").or { a > 31 }
-          }
-
-          -> {
+          exception = -> {
+            query = Proc.new { where(name: "MG").or { a > 31 } }
             @adapter.query(collection, &query).all
           }.must_raise(Lotus::Model::InvalidQueryError)
+
+          exception.message.must_equal "Invalid query"
         end
 
         it "accepts nested block conditions" do
-          query  = Proc.new {
+          query = Proc.new {
             where { name == "L" }.or { name == 'MG' }.or { name == "JS" }
           }
 
@@ -561,7 +558,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
         end
 
         it "takes into account both hash and block conditions" do
-          query  = Proc.new {
+          query = Proc.new {
             where(age: 32).or { name == 'MG' }
           }
 

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -360,7 +360,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
         it 'accepts a block as condition' do
           query  = Proc.new {
-            where{ age > 31 }
+            where { age > 31 }
           }
 
           result = @adapter.query(collection, &query).all
@@ -454,7 +454,7 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
         it 'accepts a block as condition' do
           query  = Proc.new {
-            exclude{ age > 31 }
+            exclude { age > 31 }
           }
 
           result = @adapter.query(collection, &query).all

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -357,6 +357,33 @@ describe Lotus::Model::Adapters::MemoryAdapter do
           result = @adapter.query(collection, &query).all
           result.must_equal [@user2, @user3]
         end
+
+        it 'accepts a block as condition' do
+          query  = Proc.new {
+            where{ age > 31 }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user1]
+        end
+
+        it "accepts nested block conditions" do
+          query  = Proc.new {
+            where { age > 31 }.where { name == 'L' }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user1]
+        end
+
+        it "takes into account both hash and block conditions" do
+          query  = Proc.new {
+            where(age: 32).where { name == 'L' }
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.must_equal [@user1]
+        end
       end
     end
 

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -332,6 +332,15 @@ describe Lotus::Model::Adapters::SqlAdapter do
           result.must_equal [@user1]
         end
 
+        it 'raises InvalidQueryError if you use wrong column names' do
+          -> {
+            query = Proc.new {
+              where { a > 31 }
+            }
+            @adapter.query(collection, &query).all
+          }.must_raise(Lotus::Model::InvalidQueryError)
+        end
+
         it 'raises an error if you dont specify condition or block' do
           -> {
             query = Proc.new {
@@ -396,6 +405,14 @@ describe Lotus::Model::Adapters::SqlAdapter do
 
           result = @adapter.query(collection, &query).all
           result.must_equal [@user3]
+        end
+
+        it 'raises InvalidQueryError if you use wrong column names' do
+          -> {
+            query = Proc.new { exclude{ a > 32 } }
+
+            @adapter.query(collection, &query).all
+          }.must_raise(Lotus::Model::InvalidQueryError)
         end
 
         it 'can use lambda to describe exclude conditions' do
@@ -467,6 +484,19 @@ describe Lotus::Model::Adapters::SqlAdapter do
             }
             @adapter.query(collection, &query).all
           }.must_raise(ArgumentError)
+        end
+
+        it 'raises InvalidQueryError if you use wrong column names' do
+          -> {
+            name1 = @user1.name
+            name2 = @user2.name
+
+            query = Proc.new {
+              where(name: name1).or(n: name2)
+            }
+
+            @adapter.query(collection, &query).all
+          }.must_raise(Lotus::Model::InvalidQueryError)
         end
       end
     end

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -333,12 +333,12 @@ describe Lotus::Model::Adapters::SqlAdapter do
         end
 
         it 'raises InvalidQueryError if you use wrong column names' do
-          -> {
-            query = Proc.new {
-              where { a > 31 }
-            }
+          exception = -> {
+            query = Proc.new { where { a > 31 } }
             @adapter.query(collection, &query).all
           }.must_raise(Lotus::Model::InvalidQueryError)
+
+          exception.message.wont_be_nil
         end
 
         it 'raises an error if you dont specify condition or block' do
@@ -408,11 +408,12 @@ describe Lotus::Model::Adapters::SqlAdapter do
         end
 
         it 'raises InvalidQueryError if you use wrong column names' do
-          -> {
+          exception = -> {
             query = Proc.new { exclude{ a > 32 } }
-
             @adapter.query(collection, &query).all
           }.must_raise(Lotus::Model::InvalidQueryError)
+
+          exception.message.wont_be_nil
         end
 
         it 'can use lambda to describe exclude conditions' do
@@ -487,16 +488,15 @@ describe Lotus::Model::Adapters::SqlAdapter do
         end
 
         it 'raises InvalidQueryError if you use wrong column names' do
-          -> {
+          exception = -> {
             name1 = @user1.name
             name2 = @user2.name
-
-            query = Proc.new {
-              where(name: name1).or(n: name2)
-            }
+            query = Proc.new { where(name: name1).or(n: name2) }
 
             @adapter.query(collection, &query).all
           }.must_raise(Lotus::Model::InvalidQueryError)
+
+          exception.message.wont_be_nil
         end
       end
     end


### PR DESCRIPTION
**[WIP]** Closes #165 

Hey guys, this is my **initial** :yum: implementation of the block conditions in our memory adapter. I decided to open this early PR to get some thoughts from you about my design decisions. 

The next steps for this feature would be to extract some private methods from `#where`, since it's getting longer than it should be (and it really bothers me to use `elsif` :hamster:). Finally, change both #or and #exclude in order to allow block conditions as well. But before all that, I want to know if my `OpenStruct` approach is good enough for me to continue with this design. 

I decided to use it since the other alternative I came up with was to deserialize the entities and perform the `find_all` search (since the block uses methods and not hash keys), and I really think that this is not a good approach. 

If you guys have a better idea please let me know, and I will continue with the refactors and remaining changes in `#or` and `#exclude`.

Thanks !