### PR TITLE
Extract push to condition behavior into private method

### DIFF
--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -117,9 +117,8 @@ module Lotus
           #   query.where{ age > 10 }
           #
           #   # => SELECT * FROM `users` WHERE (`age` > 31)
-          def where(condition=nil, &blk)
-            condition = (condition or blk or raise ArgumentError.new('You need to specify a condition.'))
-            conditions.push([:where, condition])
+          def where(condition = nil, &blk)
+            _push_to_conditions(:where, condition || blk)
             self
           end
 
@@ -162,9 +161,8 @@ module Lotus
           #   query.where(name: 'John').or{ age > 31 }
           #
           #   # => SELECT * FROM `users` WHERE ((`name` = 'John') OR (`age` < 32))
-          def or(condition=nil, &blk)
-            condition = (condition or blk or raise ArgumentError.new('You need to specify a condition.'))
-            conditions.push([:or, condition])
+          def or(condition = nil, &blk)
+            _push_to_conditions(:or, condition || blk)
             self
           end
 
@@ -209,9 +207,8 @@ module Lotus
           #   query.exclude{ age > 31 }
           #
           #   # => SELECT * FROM `users` WHERE (`age` <= 31)
-          def exclude(condition=nil, &blk)
-            condition = (condition or blk or raise ArgumentError.new('You need to specify a condition.'))
-            conditions.push([:exclude, condition])
+          def exclude(condition = nil, &blk)
+            _push_to_conditions(:exclude, condition || blk)
             self
           end
 
@@ -661,6 +658,11 @@ module Lotus
             dup.tap do |result|
               result.conditions.push(*query.conditions)
             end
+          end
+
+          def _push_to_conditions(condition_type, condition)
+            raise ArgumentError, 'You need to specify a condition.' unless condition
+            conditions.push([condition_type, condition])
           end
 
           def _order_operator

--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -670,8 +670,7 @@ module Lotus
           # @raise [ArgumentError] if condition is not specified.
           #
           # @api private
-          # @since 0.3.1
-          #
+          # @since x.x.x
           def _push_to_conditions(condition_type, condition)
             raise ArgumentError.new('You need to specify a condition.') if condition.nil?
             conditions.push([condition_type, condition])

--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -208,7 +208,7 @@ module Lotus
           #
           #   # => SELECT * FROM `users` WHERE (`age` <= 31)
           def exclude(condition = nil, &blk)
-            _push_to_conditions(:exclude, condition || blk)
+            _push_to_conditions(:exclude, condition || blk).inspect
             self
           end
 
@@ -660,8 +660,20 @@ module Lotus
             end
           end
 
+          # Stores a query condition of a specified type in the conditions array.
+          #
+          # @param condition_type [Symbol] the condition type. (eg. `:where`, `:or`)
+          # @param condition [Hash, Proc] the query condition to be stored.
+          #
+          # @return [Array<Array>] the conditions array itself.
+          #
+          # @raise [ArgumentError] if condition is not specified.
+          #
+          # @api private
+          # @since 0.3.1
+          #
           def _push_to_conditions(condition_type, condition)
-            raise ArgumentError, 'You need to specify a condition.' unless condition
+            raise ArgumentError.new('You need to specify a condition.') if condition.nil?
             conditions.push([condition_type, condition])
           end
 


### PR DESCRIPTION
Hey guys !

Not sure you are interested in something like this for now, but I noticed that we duplicated the exact same logic (push some data to `conditions`, and exception handling) in three methods after adding expression capability to SQL Adapter. It is good to keep this kind of stuff centralized in one place, for obvious maintainability reasons. 

So, this minor refactor brings this logic into its own private method (it seems the best place for me, since it is totally a helper method) and changes the affected methods to call this new extracted method.

If you guys have any thoughts about this, I'm here to help :yellow_heart: 

Thank you !