### PR TITLE
Removed unnecessary inspect call from sql adapter

### DIFF
--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -207,13 +207,14 @@ module Lotus
           #        .exclude(company: 'enterprise')
           #
           #   # => SELECT * FROM `projects` WHERE (`language` != 'java') AND (`company` != 'enterprise')
+          #
           # @example Expressions
           #
           #   query.exclude{ age > 31 }
           #
           #   # => SELECT * FROM `users` WHERE (`age` <= 31)
           def exclude(condition = nil, &blk)
-            _push_to_conditions(:exclude, condition || blk).inspect
+            _push_to_conditions(:exclude, condition || blk)
             self
           end
 


### PR DESCRIPTION
Hi guys ! 

Not sure why or how I let this happen, but I discovered today that I forgot a `inspect` call on sql adapter :hankey:. This PR removes it, and adds a new line to improve the API docs readability.

Truly sorry about this guys ! :cry: 