### PR TITLE
Use createdb to create database

### DIFF
--- a/lib/lotus/model/migrator/postgres_adapter.rb
+++ b/lib/lotus/model/migrator/postgres_adapter.rb
@@ -25,7 +25,7 @@ module Lotus
         # @since 0.4.0
         # @api private
         def create
-          new_connection.run %(CREATE DATABASE "#{ database }"#{ create_options })
+          `createdb #{ database } #{ create_options }`
         end
 
         # @since 0.4.0
@@ -63,7 +63,7 @@ module Lotus
         # @api private
         def create_options
           result  = ""
-          result += %( OWNER "#{ username }") unless username.nil?
+          result += %( --owner=#{ username }) unless username.nil?
           result
         end
 


### PR DESCRIPTION
Sequel can’t execute `CREATE` against postgresql. This changes the `create` method to use the `createdb` shell command to create a new database.

Fixes #199

Longer term I think that the that this should be separated out, similar to the [sequel-rails](https://github.com/TalentBox/sequel-rails) gem? Unless of course it has been decided to tie lotus-model into Sequel only. :)