### PR TITLE
Removed dump warnings and added name test to database

### DIFF
--- a/test/integration/migrations_test.rb
+++ b/test/integration/migrations_test.rb
@@ -2,6 +2,9 @@ require 'test_helper'
 require 'lotus/model/migrator'
 
 describe "Database migrations" do
+  let(:db_prefix)    { name.gsub(/[^\w]/, '_') }
+  let(:random_token) { SecureRandom.hex(4) }
+
   before do
     Lotus::Model.unload!
   end
@@ -356,7 +359,7 @@ describe "Database migrations" do
 
   describe "PostgreSQL" do
     before do
-      @database  = "migrations-#{ SecureRandom.hex }"
+      @database  = "#{ db_prefix }_#{ random_token }"
       @uri = uri = "postgres://localhost/#{ @database }?user=#{ POSTGRES_USER }"
 
       Lotus::Model.configure do
@@ -614,7 +617,6 @@ SQL
       it "creates database, loads schema and migrate" do
         # Simulate already existing schema.sql, without existing database and pending migrations
         connection = Sequel.connect(@uri)
-        Lotus::Model::Migrator::Adapter.for(connection).dump
 
         FileUtils.cp 'test/fixtures/20150611165922_create_authors.rb',
           @migrations_root.join('migrations/20150611165922_create_authors.rb')
@@ -674,7 +676,7 @@ SQL
 
   describe "MySQL" do
     before do
-      @database  = "migrations#{ SecureRandom.hex }"
+      @database  = "#{ db_prefix }_#{ random_token }"
       @uri = uri = "mysql2://#{ MYSQL_USER }@localhost/#{ @database }"
 
       Lotus::Model.configure do
@@ -924,7 +926,6 @@ SQL
       it "creates database, loads schema and migrate" do
         # Simulate already existing schema.sql, without existing database and pending migrations
         connection = Sequel.connect(@uri)
-        Lotus::Model::Migrator::Adapter.for(connection).dump
 
         FileUtils.cp 'test/fixtures/20150611165922_create_authors.rb',
           @migrations_root.join('migrations/20150611165922_create_authors.rb')


### PR DESCRIPTION
Thanks to @jodosha I added a trick, the test's name to database and I remove two dumps lines in mysql and postgresql because they are unnecessary.

With this PR we avoid these warnings:

`mysqldump: Got error: 1049: Unknown database 'database_name' when selecting the database`
`pg_dump: [archiver (bd)] falló la conexión a la base de datos «database_name»: FATAL:  database "database_name" does not exist`