### PR TITLE
Implement command/query separation for Repository, by introducing #fetch

### DIFF
--- a/lib/lotus/model.rb
+++ b/lib/lotus/model.rb
@@ -28,8 +28,16 @@ module Lotus
     class InvalidMappingError < ::StandardError
     end
 
-    # Error for invalid query
-    # It's raised when a query is malformed
+    # Error for invalid raw command syntax
+    #
+    # @since x.x.x
+    class InvalidCommandError < ::StandardError
+      def initialize(message = "Invalid command")
+        super
+      end
+    end
+
+    # Error for invalid raw query syntax
     #
     # @since 0.3.1
     class InvalidQueryError < ::StandardError

--- a/lib/lotus/model/adapters/abstract.rb
+++ b/lib/lotus/model/adapters/abstract.rb
@@ -202,13 +202,26 @@ module Lotus
           raise NotSupportedError
         end
 
-        # Executes a raw statement directly on the connection
+        # Executes a raw command
         #
         # @param raw [String] the raw statement to execute on the connection
-        # @return [Object]
+        #
+        # @return [NilClass]
         #
         # @since 0.3.1
         def execute(raw)
+          raise NotImplementedError
+        end
+
+        # Fetches raw records from
+        #
+        # @param raw [String] the raw query
+        # @param blk [Proc] an optional block that is yielded for each record
+        #
+        # @return [Enumerable<Hash>, Array<Hash>]
+        #
+        # @since x.x.x
+        def fetch(raw, &blk)
           raise NotImplementedError
         end
       end

--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -227,18 +227,42 @@ module Lotus
           Sql::Console.new(@uri).connection_string
         end
 
-        # Executes raw sql directly on the connection
+        # Executes a raw SQL command
         #
-        # @param raw [String] the raw sql statement to execute on the connection
-        # @return [Object]
+        # @param raw [String] the raw SQL statement to execute on the connection
+        #
+        # @return [NilClass]
+        #
+        # @raise [Lotus::Model::InvalidCommandError] if the raw SQL statement is invalid
         #
         # @since 0.3.1
         def execute(raw)
           begin
             @connection.execute(raw)
+            nil
           rescue Sequel::DatabaseError => e
-            raise Lotus::Model::InvalidQueryError.new(e.message)
+            raise Lotus::Model::InvalidCommandError.new(e.message)
           end
+        end
+
+        # Fetches raw result sets for the given SQL query
+        #
+        # @param raw [String] the raw SQL query
+        # @param blk [Proc] optional block that is yielded for each record
+        #
+        # @return [Array]
+        #
+        # @raise [Lotus::Model::InvalidQueryError] if the raw SQL statement is invalid
+        #
+        # @since x.x.x
+        def fetch(raw, &blk)
+          if block_given?
+            @connection.fetch(raw, &blk)
+          else
+            @connection.fetch(raw).to_a
+          end
+        rescue Sequel::DatabaseError => e
+          raise Lotus::Model::InvalidQueryError.new(e.message)
         end
 
         private

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -552,6 +552,7 @@ module Lotus
       end
 
       private
+
       # Executes the given raw statement on the adapter.
       #
       # Please note that it's only supported by some databases,
@@ -561,10 +562,13 @@ module Lotus
       # For advanced scenarios, please check the documentation of each adapter.
       #
       # @param raw [String] the raw statement to execute on the connection
-      # @return [Object] the raw result set from SQL adapter
+      #
+      # @return [NilClass]
       #
       # @raise [NotImplementedError] if current Lotus::Model adapter doesn't
       #   implement `execute`.
+      #
+      # @raise [Lotus::Model::InvalidCommandError] if the raw statement is invalid
       #
       # @see Lotus::Model::Adapters::Abstract#execute
       # @see Lotus::Model::Adapters::SqlAdapter#execute
@@ -581,19 +585,120 @@ module Lotus
       #
       #   class ArticleRepository
       #     include Lotus::Repository
+      #
+      #     def self.reset_comments_count
+      #       execute "UPDATE articles SET comments_count = 0"
+      #     end
       #   end
       #
-      #   article = Article.new(title: 'Introducing transactions',
-      #     body: 'lorem ipsum')
-      #
-      #   result_set = ArticleRepository.execute("SELECT * FROM articles")
-      #   result_set.each_hash do |result|
-      #     result # -> { id: 123, title: "Introducing transactions", body: "lorem ipsum"}
-      #   end
-      #
-      #   puts result_set.class # => SQLite3::ResultSet
+      #   ArticleRepository.reset_comments_count
       def execute(raw)
         @adapter.execute(raw)
+      end
+
+      # Fetch raw result sets for the the given statement.
+      #
+      # PLEASE NOTE: The returned result set contains an array of hashes.
+      #              The columns are returned as they are from the database,
+      #              the mapper is bypassed here.
+      #
+      # @param raw [String] the raw statement used to fetch records
+      # @param blk [Proc] an optional block that is yielded for each record
+      #
+      # @return [Enumerable<Hash>,Array<Hash>] the collection of raw records
+      #
+      # @raise [NotImplementedError] if current Lotus::Model adapter doesn't
+      #   implement `fetch`.
+      #
+      # @raise [Lotus::Model::InvalidQueryError] if the raw statement is invalid
+      #
+      # @since x.x.x
+      #
+      # @example Basic Usage
+      #   require 'lotus/model'
+      #
+      #   mapping do
+      #     collection :articles do
+      #       attribute :id,    Integer, as: :s_id
+      #       attribute :title, String,  as: :s_title
+      #     end
+      #   end
+      #
+      #   class Article
+      #     include Lotus::Entity
+      #     attributes :title, :body
+      #   end
+      #
+      #   class ArticleRepository
+      #     include Lotus::Repository
+      #
+      #     def self.all_raw
+      #       fetch("SELECT * FROM articles")
+      #     end
+      #   end
+      #
+      #   ArticleRepository.all_raw
+      #     # => [{:_id=>1, :user_id=>nil, :s_title=>"Art 1", :comments_count=>nil, :umapped_column=>nil}]
+      #
+      # @example Map A Value From Result Set
+      #   require 'lotus/model'
+      #
+      #   mapping do
+      #     collection :articles do
+      #       attribute :id,    Integer, as: :s_id
+      #       attribute :title, String,  as: :s_title
+      #     end
+      #   end
+      #
+      #   class Article
+      #     include Lotus::Entity
+      #     attributes :title, :body
+      #   end
+      #
+      #   class ArticleRepository
+      #     include Lotus::Repository
+      #
+      #     def self.titles
+      #       fetch("SELECT s_title FROM articles").map do |article|
+      #         article[:s_title]
+      #       end
+      #     end
+      #   end
+      #
+      #   ArticleRepository.titles # => ["Announcing Lotus v0.5.0"]
+      #
+      # @example Passing A Block
+      #   require 'lotus/model'
+      #
+      #   mapping do
+      #     collection :articles do
+      #       attribute :id,    Integer, as: :s_id
+      #       attribute :title, String,  as: :s_title
+      #     end
+      #   end
+      #
+      #   class Article
+      #     include Lotus::Entity
+      #     attributes :title, :body
+      #   end
+      #
+      #   class ArticleRepository
+      #     include Lotus::Repository
+      #
+      #     def self.titles
+      #       result = []
+      #
+      #       fetch("SELECT s_title FROM articles") do |article|
+      #         result << article[:s_title]
+      #       end
+      #
+      #       result
+      #     end
+      #   end
+      #
+      #   ArticleRepository.titles # => ["Announcing Lotus v0.5.0"]
+      def fetch(raw, &blk)
+        @adapter.fetch(raw, &blk)
       end
 
       # Fabricates a query and yields the given block to access the low level

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -49,8 +49,28 @@ class ArticleRepository
     rank.by_user(user)
   end
 
-  def self.aggregate
-    execute("select * from articles")
+  def self.reset_comments_count
+    execute("UPDATE articles SET comments_count = '0'")
+  end
+
+  def self.find_raw
+    fetch("SELECT * FROM articles")
+  end
+
+  def self.each_titles
+    result = []
+
+    fetch("SELECT s_title FROM articles") do |article|
+      result << article[:s_title]
+    end
+
+    result
+  end
+
+  def self.map_titles
+    fetch("SELECT s_title FROM articles").map do |article|
+      article[:s_title]
+    end
   end
 end
 

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -453,14 +453,55 @@ describe Lotus::Repository do
     end
 
     describe '.execute' do
+      before do
+        ArticleRepository.clear
+        @article = ArticleRepository.create(Article.new(title: 'WAT', comments_count: 100))
+      end
+
       it 'is a private method' do
-        -> { ArticleRepository.execute("select * from articles") }.must_raise NoMethodError
+        -> { ArticleRepository.execute("UPDATE articles SET comments_count = '0'") }.must_raise NoMethodError
       end
 
       it 'returns the ResultSet from the executes sql' do
-        result = ArticleRepository.aggregate
-        result.class.name.must_equal "SQLite3::ResultSet"
-        result.count.must_equal 1
+        result = ArticleRepository.reset_comments_count
+        result.must_be_nil
+
+        ArticleRepository.find(@article.id).comments_count.must_equal 0
+      end
+    end
+
+    describe '.fetch' do
+      before do
+        ArticleRepository.clear
+        @article = ArticleRepository.create(Article.new(title: 'Art 1'))
+      end
+
+      it 'is a private method' do
+        -> { ArticleRepository.fetch("SELECT s_title FROM articles") }.must_raise NoMethodError
+      end
+
+      it 'returns the raw ResultSet for the given SQL' do
+        result = ArticleRepository.find_raw
+
+        result.must_be_kind_of(::Array)
+        result.size.must_equal(1)
+
+        article = result.first
+        article[:_id].must_equal            @article.id
+        article[:user_id].must_equal        @article.user_id
+        article[:s_title].must_equal        @article.title
+        article[:comments_count].must_equal @article.comments_count
+        article[:unmapped_column].must_be_nil
+      end
+
+      it 'yields a block' do
+        result = ArticleRepository.each_titles
+        result.must_equal ['Art 1']
+      end
+
+      it 'returns an enumerable' do
+        result = ArticleRepository.map_titles
+        result.must_equal ['Art 1']
       end
     end
 
@@ -488,11 +529,21 @@ describe Lotus::Repository do
 
     describe '.execute' do
       it 'is a private method' do
-        -> { ArticleRepository.execute("select * from articles") }.must_raise NoMethodError
+        -> { ArticleRepository.execute("UPDATE articles SET comments_count = '0'") }.must_raise NoMethodError
       end
 
       it "raises an exception because memory adapter doesn't support execute" do
-        -> { ArticleRepository.aggregate }.must_raise NotImplementedError
+        -> { ArticleRepository.reset_comments_count }.must_raise NotImplementedError
+      end
+    end
+
+    describe '.fetch' do
+      it 'is a private method' do
+        -> { ArticleRepository.fetch("SELECT * FROM articles") }.must_raise NoMethodError
+      end
+
+      it "raises an exception because memory adapter doesn't support fetch" do
+        -> { ArticleRepository.find_raw }.must_raise NotImplementedError
       end
     end
   end


### PR DESCRIPTION
### Repository.execute

This PR introduces a breaking change: `Repository.execute` will return `nil`.

This method is still useful if we want to send commands against a database, without expecting any returning value.

```ruby
class ArticleRepository
  include Lotus::Repository

  def self.reset_comment_count
    execute "UPDATE articles SET comments_count = 0"
  end
end
```

### Repository.fetch

In order to retrieve raw records from the database, we have introduced `.fetch`.
**It will return a collection of hashes, representing the RAW records as they are returned from the database, WITHOUT involving coercions and mapper**.

Given the following mapping:

```ruby
collection :articles do
  # ...
  attribute :id, Integer, as: :s_id
  attribute :title, Integer, as: s_title
end
```

It will return

```ruby
class ArticleRepository
  include Lotus::Repository

  def self.find_raw
    fetch "SELECT * FROM articles"
  end
end


ArticleRepository.find_raw
  # => [{:s_id=>"1", :s_title=>"Art 1"}] # They are not coerced or mapped
```

Ref #191 

/cc @lotus/core-team