### PR TITLE
Fix documentation for create/persist.

### DIFF
--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -216,7 +216,7 @@ module Lotus
       #
       # @param entity [#id, #id=] the entity to persist
       #
-      # @return [Object] the entity
+      # @return [Object] a copy of the entity with `id` assigned
       #
       # @since 0.1.0
       #
@@ -233,8 +233,9 @@ module Lotus
       #   article = Article.new(title: 'Introducing Lotus::Model')
       #   article.id # => nil
       #
-      #   ArticleRepository.persist(article) # creates a record
-      #   article.id # => 23
+      #   persisted_article = ArticleRepository.persist(article) # creates a record
+      #   article.id # => nil
+      #   persisted_article.id # => 23
       #
       # @example With a persisted entity
       #   require 'lotus/model'
@@ -257,13 +258,13 @@ module Lotus
       end
 
       # Creates a record in the database for the given entity.
-      # It assigns the `id` attribute, in case of success.
+      # It returns a copy of the entity with `id` assigned.
       #
       # If already persisted (`id` present) it does nothing.
       #
       # @param entity [#id,#id=] the entity to create
       #
-      # @return [Object] the entity
+      # @return [Object] a copy of the entity with `id` assigned
       #
       # @since 0.1.0
       #
@@ -279,8 +280,9 @@ module Lotus
       #   article = Article.new(title: 'Introducing Lotus::Model')
       #   article.id # => nil
       #
-      #   ArticleRepository.create(article) # creates a record
-      #   article.id # => 23
+      #   created_article = ArticleRepository.create(article) # creates a record
+      #   article.id # => nil
+      #   created_article.id # => 23
       #
       #   ArticleRepository.create(article) # no-op
       def create(entity)

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -284,7 +284,12 @@ module Lotus
       #   article.id # => nil
       #   created_article.id # => 23
       #
-      #   ArticleRepository.create(article) # no-op
+      #   created_article = ArticleRepository.create(article)
+      #   created_article.id # => 24
+      #
+      #   created_article = ArticleRepository.create(existing_article) # => no-op
+      #   created_article # => nil
+      #
       def create(entity)
         unless _persisted?(entity)
           _touch(entity)

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -45,6 +45,16 @@ describe Lotus::Repository do
             persisted_user.age.must_equal(unpersisted_user.age.to_i)
           end
 
+          it 'returns a copy of the entity passed as argument' do
+            persisted_user = UserRepository.persist(unpersisted_user)
+            refute_same persisted_user, unpersisted_user
+          end
+
+          it 'does not assign an id on the entity passed as argument' do
+            UserRepository.persist(unpersisted_user)
+            unpersisted_user.id.must_be_nil
+          end
+
           it 'should coerce attributes' do
             persisted_user = UserRepository.persist(unpersisted_user)
             persisted_user.age.must_equal(25)

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -118,6 +118,12 @@ describe Lotus::Repository do
           user1.id.must_equal id
         end
 
+        it 'returns nil when trying to create an already persisted entity' do
+          created_user = UserRepository.create(User.new(name: 'Pascal'))
+          value = UserRepository.create(created_user)
+          value.must_be_nil
+        end
+
         describe 'when entity is not persisted' do
           let(:unpersisted_user) { User.new(name: 'My', age: '23') }
 


### PR DESCRIPTION
create/persist do not assign the id to the entity passed as parameter.
Instead they return a copy of the entity with id assigned.