### PR TITLE
Add jRuby 9k support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: ruby
 sudo: false
 cache: bundler
-script: 'bundle exec rake test:coverage'
+install: true
+script:
+  - 'if [[ "$TRAVIS_RUBY_VERSION" =~ "jruby" ]]; then rvm get head && rvm reload && rvm use --install $TRAVIS_RUBY_VERSION; fi'
+  - 'bundle install'
+  - 'bundle exec rake test:coverage'
 rvm:
   - 2.0.0
   - 2.1.0
@@ -19,10 +23,9 @@ rvm:
   - jruby-head
 
 addons:
-  postgresql: "9.4"
+  postgresql: '9.4'
 
 matrix:
   allow_failures:
     - rvm: rbx-2
     - rvm: jruby-head
-    - rvm: jruby-9000

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,13 @@ end
 gem 'lotus-utils',       '~> 0.5', require: false, github: 'lotus/utils',       branch: '0.5.x'
 gem 'lotus-validations',           require: false, github: 'lotus/validations', branch: '0.3.x'
 
-gem 'sqlite3',      require: false, platforms: :ruby
-gem 'jdbc-sqlite3', require: false, platforms: :jruby
-gem 'pg'
-gem 'mysql2'
+gem 'sqlite3', require: false, platforms: :ruby
+gem 'pg',                      platforms: :ruby
+gem 'mysql2',                  platforms: :ruby
+
+gem 'jdbc-sqlite3',  require: false, platforms: :jruby
+gem 'jdbc-postgres', require: false, platforms: :jruby
+gem 'jdbc-mysql',    require: false, platforms: :jruby
 
 gem 'simplecov', require: false
 gem 'coveralls', require: false

--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -230,15 +230,17 @@ module Lotus
         # Executes raw sql directly on the connection
         #
         # @param raw [String] the raw sql statement to execute on the connection
+        # @param block [Proc] code to be executed directly in the adapter context, with that you can
+        # manipulate low level ResultSet objects.
         #
         # @return [Object]
         #
         # @raise [Lotus::Model::InvalidQueryError] if raw statement is invalid
         #
         # @since 0.3.1
-        def execute(raw)
+        def execute(raw, &block)
           begin
-            @connection.execute(raw)
+            @connection.execute(raw, &block)
           rescue Sequel::DatabaseError => e
             raise Lotus::Model::InvalidQueryError.new(e.message)
           end

--- a/lib/lotus/model/migrator.rb
+++ b/lib/lotus/model/migrator.rb
@@ -1,5 +1,6 @@
 require 'sequel'
 require 'sequel/extensions/migration'
+require 'lotus/model/migrator/connection'
 require 'lotus/model/migrator/adapter'
 
 module Lotus

--- a/lib/lotus/model/migrator/connection.rb
+++ b/lib/lotus/model/migrator/connection.rb
@@ -1,0 +1,133 @@
+module Lotus
+  module Model
+    module Migrator
+      # Sequel connection wrapper
+      #
+      # Normalize external adapters interfaces
+      #
+      # @since x.x.x
+      # @api private
+      class Connection
+        attr_reader :adapter_connection
+
+        def initialize(adapter_connection)
+          @adapter_connection = adapter_connection
+        end
+
+        # Returns DB connection host
+        #
+        # Even when adapter doesn't provide it explicitly it tries to parse
+        #
+        # @since x.x.x
+        # @api private
+        def host
+          @host ||= opts.fetch(:host, parsed_uri.host)
+        end
+
+        # Returns DB connection port
+        #
+        # Even when adapter doesn't provide it explicitly it tries to parse
+        #
+        # @since x.x.x
+        # @api private
+        def port
+          @port ||= opts.fetch(:port, parsed_uri.port)
+        end
+
+        # Returns DB name from conenction
+        #
+        # Even when adapter doesn't provide it explicitly it tries to parse
+        #
+        # @since x.x.x
+        # @api private
+        def database
+          @database ||= opts.fetch(:database, parsed_uri.path[1..-1])
+        end
+
+        # Returns DB type
+        #
+        # @example
+        #   connection.database_type
+        #   # => 'postgres'
+        #
+        # @since x.x.x
+        # @api private
+        def database_type
+          adapter_connection.database_type
+        end
+
+        # Returns user from DB connection
+        #
+        # Even when adapter doesn't provide it explicitly it tries to parse
+        #
+        # @since x.x.x
+        # @api private
+        def user
+          @user ||= opts.fetch(:user, parsed_opt('user'))
+        end
+
+        # Returns user from DB connection
+        #
+        # Even when adapter doesn't provide it explicitly it tries to parse
+        #
+        # @since x.x.x
+        # @api private
+        def password
+          @password ||= opts.fetch(:password, parsed_opt('password'))
+        end
+
+        # Returns DB connection URI directly from adapter
+        #
+        # @since x.x.x
+        # @api private
+        def uri
+          adapter_connection.uri
+        end
+
+        # Returns DB connection wihout specifying database name
+        #
+        # @since x.x.x
+        # @api private
+        def global_uri
+          adapter_connection.uri.sub(parsed_uri.select(:path).first, '')
+        end
+
+        # Returns a boolean telling if a DB connection is from JDBC or not
+        #
+        # @since x.x.x
+        # @api private
+        def jdbc?
+          !adapter_connection.uri.scan('jdbc:').empty?
+        end
+
+        # Returns database connection URI instance without JDBC namespace
+        #
+        # @since x.x.x
+        # @api private
+        def parsed_uri
+          @uri ||= URI.parse(adapter_connection.uri.sub('jdbc:', ''))
+        end
+
+        private
+
+        # Returns a value of a given query string param
+        #
+        # @param option [String] which option from database connection will be extracted from URI
+        #
+        # @since x.x.x
+        # @api private
+        def parsed_opt(option)
+          parsed_uri.to_s.match(/[\?|\&]#{ option }=(\w+)\&?/).to_a.last
+        end
+
+        # Fetch connection options from adapter
+        #
+        # @since x.x.x
+        # @api private
+        def opts
+          adapter_connection.opts
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/model/migrator/mysql_adapter.rb
+++ b/lib/lotus/model/migrator/mysql_adapter.rb
@@ -9,13 +9,13 @@ module Lotus
         # @since 0.4.0
         # @api private
         def create
-          new_connection.run %(CREATE DATABASE #{ database };)
+          new_connection(global: true).run %(CREATE DATABASE #{ database };)
         end
 
         # @since 0.4.0
         # @api private
         def drop
-          new_connection.run %(DROP DATABASE #{ database };)
+          new_connection(global: true).run %(DROP DATABASE #{ database };)
         rescue Sequel::DatabaseError => e
           message = if e.message.match(/doesn\'t exist/)
             "Cannot find database: #{ database }"

--- a/lib/lotus/model/migrator/sqlite_adapter.rb
+++ b/lib/lotus/model/migrator/sqlite_adapter.rb
@@ -69,7 +69,7 @@ module Lotus
         # @api private
         def path
           root.join(
-            @connection.uri.sub(/#{ @connection.adapter_scheme }\:\/\//, '')
+            @connection.uri.sub(/(jdbc\:|)sqlite\:\/\//, '')
           )
         end
 

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -607,8 +607,8 @@ module Lotus
       #   end
       #
       #   puts result_set.class # => SQLite3::ResultSet
-      def execute(raw)
-        @adapter.execute(raw)
+      def execute(raw, &block)
+        @adapter.execute(raw, &block)
       end
 
       # Fabricates a query and yields the given block to access the low level

--- a/test/fixtures.rb
+++ b/test/fixtures.rb
@@ -49,8 +49,8 @@ class ArticleRepository
     rank.by_user(user)
   end
 
-  def self.aggregate
-    execute("select * from articles")
+  def self.aggregate(&block)
+    execute("SELECT * FROM articles", &block)
   end
 end
 

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -2,11 +2,19 @@ require 'test_helper'
 require 'lotus/model/migrator'
 
 describe "Lotus::Model.migration" do
+  let(:adapter_prefix) { 'jdbc:' if Lotus::Utils.jruby?  }
+
+  # Dirty DB can skip migrations
+  after :teardown do
+    File.delete(@database)
+    File.delete(@schema)
+  end
+
   describe "SQLite" do
     before do
       @database = Pathname.new("#{ __dir__ }/../tmp/migration.sqlite3").expand_path
       @schema   = schema_path = Pathname.new("#{ __dir__ }/../tmp/schema.sql").expand_path
-      @uri      = uri = "sqlite://#{ @database }"
+      @uri      = uri = "#{ adapter_prefix }sqlite://#{ @database }"
 
       Lotus::Model.configure do
         adapter type: :sql, uri: uri

--- a/test/migrator/connection_test.rb
+++ b/test/migrator/connection_test.rb
@@ -1,0 +1,115 @@
+require 'test_helper'
+require 'lotus/model/migrator/connection'
+
+describe Lotus::Model::Migrator::Connection do
+  let(:connection) { Lotus::Model::Migrator::Connection.new(adapter_connection) }
+
+  let(:adapter_connection) do
+    OpenStruct.new(
+      uri: 'postgresql://postgres:s3cr3T@127.0.0.1:5432/database',
+      opts: { user: 'postgres', password: 's3cr3T' }
+    )
+  end
+
+  describe '#jdbc?' do
+    it 'returns false' do
+      connection.jdbc?.must_equal false
+    end
+  end
+
+  describe '#global_uri' do
+    it 'returns connection URI without database' do
+      connection.global_uri.scan('database').empty?.must_equal true
+    end
+  end
+
+  describe '#parsed_uri?' do
+    it 'returns an URI instance' do
+      connection.parsed_uri.must_be_kind_of URI
+    end
+  end
+
+  describe '#user' do
+    it 'returns configured user' do
+      connection.user.wont_equal nil
+      connection.user.must_equal 'postgres'
+    end
+  end
+
+  describe '#password' do
+    it 'returns configured password' do
+      connection.password.wont_equal nil
+      connection.password.must_equal 's3cr3T'
+    end
+  end
+
+  describe 'when jdbc connection' do
+    let(:adapter_connection) do
+      OpenStruct.new(
+        uri: 'jdbc:postgresql://127.0.0.1:5432/database?user=postgres&password=s3cr3T',
+        opts: {}
+      )
+    end
+
+    describe '#jdbc?' do
+      it 'returns true' do
+        connection.jdbc?.must_equal true
+      end
+    end
+
+    describe '#host' do
+      it 'returns configured host' do
+        connection.host.wont_equal nil
+        connection.host.must_equal '127.0.0.1'
+      end
+    end
+
+    describe '#port' do
+      it 'returns configured port' do
+        connection.port.wont_equal nil
+        connection.port.must_equal 5432
+      end
+    end
+
+    describe '#user' do
+      it 'returns configured user' do
+        connection.user.wont_equal nil
+        connection.user.must_equal 'postgres'
+      end
+
+      describe 'when there is no user option' do
+        let(:adapter_connection) do
+          OpenStruct.new(uri: 'jdbc:postgresql://127.0.0.1/database', opts: {})
+        end
+
+        it 'returns nil' do
+          connection.user.must_equal nil
+        end
+      end
+    end
+
+    describe '#password' do
+      it 'returns configured password' do
+        connection.password.wont_equal nil
+        connection.password.must_equal 's3cr3T'
+      end
+
+      describe 'when there is no password option' do
+        let(:adapter_connection) do
+          OpenStruct.new(uri: 'jdbc:postgresql://127.0.0.1/database', opts: {})
+        end
+
+        it 'returns nil' do
+          connection.password.must_equal nil
+        end
+      end
+    end
+
+    describe '#database' do
+      it 'returns configured database' do
+        connection.database.wont_equal nil
+        connection.database.must_equal 'database'
+      end
+    end
+  end
+end


### PR DESCRIPTION
It introduces a DB URI connection wrapper where we can hold logic of how to
deal with DB connection URLs independent from platforms.

- [x] Add jdbc libraries for jruby platform
- [x] Extract DB URI connection logic from Adapter
- [x] Add support for the current SQL adapters
  - [x] SQLite
  - [x] PostgreSQL
  - [x] MySQL
- [x] Improve `execute` interface do mimic Sequel adapter

----------------------------------------------------------------------

Important
-------------

When using `execute` directly we're adrift of the adapter, when it is
the Ruby SQlite3 adapter we get `SQlite3::ResultSet` as result,
but when dealing with Java JDBC SQLite adapter with get
`Java::OrgSqliteJdbc4::JDBC4ResultSet` which is a low level object that
doesn't have the Ruby interface that we expect.

Facing that we need to question ourselves if we want to expose the raw
adapter reponse or a object with a cross-platform normalized interface.

----------------

Part of https://github.com/lotus/lotus/pull/307