### PR TITLE
Added group query to sql

### DIFF
--- a/lib/lotus/model/adapters/memory/query.rb
+++ b/lib/lotus/model/adapters/memory/query.rb
@@ -541,6 +541,19 @@ module Lotus
             raise NotImplementedError
           end
 
+          # This method is defined in order to make the interface of
+          # `Memory::Query` identical to `Sql::Query`, but this feature is NOT
+          # implemented
+          #
+          # @raise [NotImplementedError]
+          #
+          # @since x.x.x
+          #
+          # @see Lotus::Model::Adapters::Sql::Query#group!
+          def group
+            raise NotImplementedError
+          end
+
           protected
           def method_missing(m, *args, &blk)
             if @context.respond_to?(m)

--- a/lib/lotus/model/adapters/sql/collection.rb
+++ b/lib/lotus/model/adapters/sql/collection.rb
@@ -157,6 +157,22 @@ module Lotus
             end
           end
 
+
+          # Filters the current scope with a `group` directive.
+          #
+          # @param args [Array] the array of arguments
+          #
+          # @see Lotus::Model::Adapters::Sql::Query#group
+          #
+          # @return [Lotus::Model::Adapters::Sql::Collection] the filtered
+          #   collection
+          #
+          # @api private
+          # @since x.x.x
+          def group(*args)
+            Collection.new(super, @mapped_collection)
+          end
+
           # Filters the current scope with a `where` directive.
           #
           # @param args [Array] the array of arguments

--- a/lib/lotus/model/adapters/sql/query.rb
+++ b/lib/lotus/model/adapters/sql/query.rb
@@ -401,6 +401,30 @@ module Lotus
           #   query.desc(:name).desc(:year)
           alias_method :desc, :reverse_order
 
+          # Group by the specified columns.
+          #
+          # @param columns [Array<Symbol>]
+          #
+          # @return self
+          #
+          # @since x.x.x
+          #
+          # @example Single column
+          #
+          #   query.group(:name)
+          #
+          #   # => SELECT * FROM `people` GROUP BY `name`
+          #
+          # @example Multiple columns
+          #
+          #   query.group(:name, :year)
+          #
+          #   # => SELECT * FROM `people` GROUP BY `name`, `year`
+          def group(*columns)
+            conditions.push([:group, *columns])
+            self
+          end
+
           # Returns the sum of the values for the given column.
           #
           # @param column [Symbol] the column name

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -1196,6 +1196,56 @@ describe Lotus::Model::Adapters::SqlAdapter do
       end
     end
 
+    describe 'group' do
+      describe 'with an empty collection' do
+        it 'returns an empty result' do
+          result = @adapter.query(collection) do
+            group(:name)
+          end.all
+
+          result.must_be_empty
+        end
+      end
+
+      describe 'with a filled collection' do
+        before do
+          @adapter.create(collection, user1)
+          @adapter.create(collection, user2)
+          @adapter.create(collection, user3)
+          @adapter.create(collection, user4)
+          @adapter.create(collection, user5)
+          @adapter.create(collection, user6)
+          @adapter.create(collection, user7)
+        end
+
+        let(:user1) { TestUser.new(name: 'L', age: 32) }
+        let(:user2) { TestUser.new(name: 'L', age: 10) }
+        let(:user3) { TestUser.new(name: 'L', age: 11) }
+        let(:user4) { TestUser.new(name: 'A', age: 12) }
+        let(:user5) { TestUser.new(name: 'A', age: 12) }
+        let(:user6) { TestUser.new(name: 'T', age: 11) }
+        let(:user7) { TestUser.new(name: 'O', age: 10) }
+
+        it 'returns grouped records with one column' do
+          query = Proc.new {
+            group(:name)
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.size.must_equal 4
+        end
+
+        it 'returns grouped records with 2 columns' do
+          query = Proc.new {
+            group(:name, :age)
+          }
+
+          result = @adapter.query(collection, &query).all
+          result.size.must_equal 6
+        end
+      end
+    end
+
     describe '#disconnect' do
       before do
         @adapter.disconnect


### PR DESCRIPTION
ditto

I added group query, `having` will be added in other PR.

Now you can use `GROUP BY` query with the `group` method.

```ruby
class User
  include Lotus::Entity
  attributes :name, :age
end

class UserRepository
  def grouped_by_age
    query do
      group(:age)
    end
  end
end
```