### PR TITLE
Adds simple BCrypt secure passwords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,8 @@ end
 gem 'lotus-utils',       '~> 0.5', require: false, github: 'lotus/utils',       branch: '0.5.x'
 gem 'lotus-validations',           require: false, github: 'lotus/validations', branch: '0.3.x'
 
+gem 'bcrypt', require: false
+
 platforms :ruby do
   gem 'sqlite3', require: false
   gem 'pg'

--- a/lib/lotus/entity/secure_password.rb
+++ b/lib/lotus/entity/secure_password.rb
@@ -1,0 +1,39 @@
+require 'lotus/validations'
+
+module Lotus
+  module Entity
+    module SecurePassword
+      # Maximum as permitted by bcrypt's hash function
+      MAX_LENGTH = 72
+
+      def self.included(base)
+        base.class_eval do
+          begin
+            require 'bcrypt'
+          rescue LoadError
+            STDERR.puts 'Add bcrypt to your Gemfile and `bundle install`'
+            raise
+          end
+
+          include Lotus::Validations
+          attribute :password, confirmation: true, size: 0..MAX_LENGTH
+          attribute :password_digest
+
+          def password=(unencrypted)
+            if unencrypted.nil?
+              @attributes.set(:password_digest, nil)
+            elsif !unencrypted.empty?
+              encrypted = BCrypt::Password.create(unencrypted)
+              @attributes.set(:password_digest, encrypted)
+              @attributes.set(:password, unencrypted)
+            end
+          end
+
+          def authenticate(unencrypted)
+            BCrypt::Password.new(password_digest).is_password?(unencrypted) && self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/lotus/model.rb
+++ b/lib/lotus/model.rb
@@ -1,6 +1,7 @@
 require 'lotus/model/version'
 require 'lotus/entity'
 require 'lotus/entity/dirty_tracking'
+require 'lotus/entity/secure_password'
 require 'lotus/repository'
 require 'lotus/model/mapper'
 require 'lotus/model/configuration'

--- a/test/secure_password_test.rb
+++ b/test/secure_password_test.rb
@@ -1,0 +1,77 @@
+require 'test_helper'
+
+describe Lotus::Entity::SecurePassword do
+  before do
+    class Person
+      include Lotus::Entity
+      include Lotus::Entity::SecurePassword
+    end
+  end
+
+  subject { Person.new }
+
+  it 'adds a `password` attribute' do
+    subject.must_respond_to :password
+  end
+
+  it 'adds a `password_confirmation` attribute' do
+    subject.must_respond_to :password_confirmation
+  end
+
+  it 'adds a `password_digest` attribute' do
+    subject.must_respond_to :password_digest
+  end
+
+  it 'ensures `password` is confirmed' do
+    subject.password = 'password'
+    subject.password_confirmation = 'passwelp'
+
+    subject.wont_be :valid?
+  end
+
+  it 'ensures password is no more than 72 characters' do
+    subject.password = subject.password_confirmation = '*' * 73
+
+    subject.wont_be :valid?
+  end
+
+  it 'is valid when the password is confirmed' do
+    subject.password = subject.password_confirmation = 'password'
+
+    subject.must_be :valid?
+  end
+
+  it 'assigning a nil password clears the digest' do
+    subject.password_digest = 'password'
+    subject.password = nil
+
+    subject.password_digest.must_be :nil?
+  end
+
+  it 'assigning an empty password does not modify the digest' do
+    subject.password_digest = 'password'
+    subject.password = ''
+
+    subject.password_digest.must_equal 'password'
+  end
+
+  it 'assigning a non-empty password sets the digest' do
+    subject.password = 'password'
+
+    subject.password_digest.wont_equal nil
+  end
+
+  describe '#authenticate' do
+    it 'returns `self` when the secret is correct' do
+      subject.password = 'password'
+
+      subject.authenticate('password').must_equal subject
+    end
+
+    it 'returns false when the secret is incorrect' do
+      subject.password = 'password'
+
+      subject.authenticate('incorrect').must_equal false
+    end
+  end
+end


### PR DESCRIPTION
Includes basic validation for password and confirmation. Ensures
passwords are kept below 72 characters, the theoretical maximum
permitted by bcrypt's hashing function.

I hit some troubles with Lotus validations. It was a surprise for me to
find that the validator macro creates accessors/attributes. It would
have been tidier to include a module containing the instance methods
within the `included` callback, but due to ordering with the attributes
API, and my need to overload the `password=` accessor _after_ it had
been defined by the attributes API.

Because I wanted to use the confirmation, and the `size` validators
this pushed me toward that particular approach.

Some things to note:

* BCrypt is latently loaded and needs to be present in the Gemfile,
 this will be documented of course.
* No efforts were made to abstract access to BCrypt since it's just the
 defacto approach/library. Happy to do this though if anyone feels
 strongly.
* At the moment, the hashing cost is whatever BCrypt's default is. This
 can be overridden via `BCrypt::Engine.cost=`. It may be worth
 providing a nicer API here for consumers.

I just wanted to get some validation on the approach before I
documented the code. WDYT?