### PR TITLE
Drop support for mysql adapter in favour of mysql2 adapter

### DIFF
--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -43,9 +43,8 @@ module Lotus
         # @since 0.1.0
         def initialize(mapper, uri)
           super
-          @connection = Sequel.connect(@uri)
-        rescue Sequel::AdapterNotFound => e
-          raise DatabaseAdapterNotFound.new(e.message)
+          _preprocess_uri
+          connect
         end
 
         # Creates a record in the database for the given entity.
@@ -256,6 +255,22 @@ module Lotus
         end
 
         private
+
+        # @api private
+        # @since x.x.x
+        def connect
+          @connection = Sequel.connect(@uri)
+        rescue Sequel::AdapterNotFound => e
+          raise DatabaseAdapterNotFound.new(e.message)
+        end
+
+        # Convert URI with mysql:// to mysql2://
+        #
+        # @api private
+        # @since x.x.x
+        def _preprocess_uri
+          @uri = @uri.gsub('mysql://', 'mysql2://')
+        end
 
         # Returns a collection from the given name.
         #

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -78,6 +78,11 @@ describe Lotus::Model::Adapters::SqlAdapter do
         Lotus::Model::Adapters::SqlAdapter.new(@mapper, 'unknown_db:host')
       }.must_raise(URI::InvalidURIError)
     end
+
+    it 'changes the URI of mysql:// to mysql2://' do
+      sql_adapter = Lotus::Model::Adapters::SqlAdapter.new(@mapper, 'mysql://host/db_name')
+      sql_adapter.instance_variable_get(:@uri).must_equal('mysql2://host/db_name')
+    end
   end
 
   describe '#persist' do


### PR DESCRIPTION
Sequel supports both mysql and mysql2, in majority of cases mysql2 are opted to mysql. By adopting one mysql engine, I think it would reduce the maintenance for the team and enhances the consistency