### PR TITLE
Return error_message for dropdb messages

### DIFF
--- a/lib/lotus/model/migrator/postgres_adapter.rb
+++ b/lib/lotus/model/migrator/postgres_adapter.rb
@@ -45,7 +45,7 @@ module Lotus
               message = if error_message.match(/does not exist/)
                 "Cannot find database: #{ database }"
               else
-                message
+                error_message
               end
 
               raise MigrationError.new(message)


### PR DESCRIPTION
I made a mistake with this work in the past. The return message should be the `error_message`
cc @lotus/core-team 