### PR TITLE
Check persisted using real existence (instead of id presence)

### DIFF
--- a/lib/lotus/model/adapters/abstract.rb
+++ b/lib/lotus/model/adapters/abstract.rb
@@ -91,6 +91,19 @@ module Lotus
           @uri    = uri
         end
 
+        # This is a method to check entity persited or not
+        #
+        # @param collection [Symbol] the target collection (it must be mapped).
+        # @param id [Object] the identity of the object.
+        #
+        # @return a boolean value
+        #
+        # @api private
+        # @since 0.5.1
+        def persisted?(collection, entity)
+          raise NotImplementedError
+        end
+
         # Creates or updates a record in the database for the given entity.
         #
         # @param collection [Symbol] the target collection (it must be mapped).

--- a/lib/lotus/model/adapters/implementation.rb
+++ b/lib/lotus/model/adapters/implementation.rb
@@ -6,6 +6,20 @@ module Lotus
       # @api private
       # @since 0.1.0
       module Implementation
+
+        # This is a method to check entity persited or not
+        #
+        # @param collection [Symbol] the target collection (it must be mapped).
+        # @param id [Object] the identity of the object.
+        #
+        # @return a boolean value
+        #
+        # @api private
+        # @since 0.5.1
+        def persisted?(collection, entity)
+          !!find(collection, entity.id)
+        end
+
         # Creates or updates a record in the database for the given entity.
         #
         # @param collection [Symbol] the target collection (it must be mapped).
@@ -16,7 +30,7 @@ module Lotus
         # @api private
         # @since 0.1.0
         def persist(collection, entity)
-          if entity.id
+          if persisted?(collection, entity)
             update(collection, entity)
           else
             create(collection, entity)

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -297,7 +297,7 @@ module Lotus
       #   created_article # => nil
       #
       def create(entity)
-        unless _persisted?(entity)
+        unless persisted?(entity)
           _touch(entity)
           @adapter.create(collection, entity)
         end
@@ -346,7 +346,7 @@ module Lotus
       #
       #   ArticleRepository.update(article) # raises Lotus::Model::NonPersistedEntityError
       def update(entity)
-        if _persisted?(entity)
+        if persisted?(entity)
           _touch(entity)
           @adapter.update(collection, entity)
         else
@@ -395,7 +395,7 @@ module Lotus
       #
       #   ArticleRepository.delete(article) # raises Lotus::Model::NonPersistedEntityError
       def delete(entity)
-        if _persisted?(entity)
+        if persisted?(entity)
           @adapter.delete(collection, entity)
         else
           raise Lotus::Model::NonPersistedEntityError
@@ -562,6 +562,16 @@ module Lotus
         @adapter.transaction(options) do
           yield
         end
+      end
+
+      # This is a method to check entity persited or not
+      #
+      # @param entity
+      # @return a boolean value
+      #
+      # @since 0.5.1
+      def persisted?(entity)
+        @adapter.persisted?(collection, entity)
       end
 
       private
@@ -825,15 +835,6 @@ module Lotus
       def exclude(query)
         query.negate!
         query
-      end
-
-      # This is a method to check entity persited or not
-      #
-      # @param entity
-      # @return a boolean value
-      # @since 0.3.1
-      def _persisted?(entity)
-        !!entity.id
       end
 
       # Update timestamps

--- a/test/model/adapters/abstract_test.rb
+++ b/test/model/adapters/abstract_test.rb
@@ -7,6 +7,12 @@ describe Lotus::Model::Adapters::Abstract do
   let(:query)      { Object.new }
   let(:collection) { :collection }
 
+  describe '#persisted?' do
+    it 'raises error' do
+      -> { adapter.persisted?(collection, entity) }.must_raise NotImplementedError
+    end
+  end
+
   describe '#persist' do
     it 'raises error' do
       -> { adapter.persist(collection, entity) }.must_raise NotImplementedError

--- a/test/repository_test.rb
+++ b/test/repository_test.rb
@@ -39,6 +39,31 @@ describe Lotus::Repository do
         end
       end
 
+      describe '.persisted?' do
+        describe 'when passed a non-persisted entity' do
+          let(:unpersisted_user) { User.new(name: 'Don', age: '25') }
+
+          it 'should return false' do
+            UserRepository.persisted?(unpersisted_user).must_equal false
+          end
+
+          it 'should return false if id present' do
+            unpersisted_user.id = 100
+            UserRepository.persisted?(unpersisted_user).must_equal false
+          end
+        end
+
+        describe 'when passed a persisted entity' do
+          let(:user)           { UserRepository.create(User.new(name: 'Don')) }
+          let(:persisted_user) { UserRepository.persist(user) }
+
+
+          it 'should return true' do
+            UserRepository.persisted?(persisted_user).must_equal true
+          end
+        end
+      end
+
       describe '.persist' do
         describe 'when passed a non-persisted entity' do
           let(:unpersisted_user) { User.new(name: 'Don', age: '25') }
@@ -59,6 +84,11 @@ describe Lotus::Repository do
           it 'does not assign an id on the entity passed as argument' do
             UserRepository.persist(unpersisted_user)
             unpersisted_user.id.must_be_nil
+          end
+
+          it 'persists new entity' do
+            user = UserRepository.persist(User.new(name: 'Don', id: 25))
+            UserRepository.all.must_include(user)
           end
 
           it 'should coerce attributes' do
@@ -173,6 +203,16 @@ describe Lotus::Repository do
           it 'does not touch created_at' do
             UserRepository.create(@persisted_user)
             @persisted_user.created_at.wont_be_nil
+          end
+        end
+
+        describe 'when entity has id' do
+          before do
+            @persisted_user = UserRepository.create(User.new(name: 'My', id: 234))
+          end
+
+          it 'persist entities' do
+            UserRepository.all.must_include(@persisted_user)
           end
         end
       end


### PR DESCRIPTION
Currently if the entity has `id`,
```ruby
user = User.new({id: 123, login: 'aderyabin'})
```
there are no way to persist this entity because `.create` returns nil because id are present and `.update` fails because record in database with this `id` are not exists.

I suggest to check on persistance by real query to repository. If repository do not have entity with the equal id then and entity are not persisted.

It easy to display by example/test:
```ruby
user = UserRepository.create(User.new(name: 'Don', id: 25))
UserRepository.all.must_include(user)
```


// cc @AlfonsoUceda, you asked me to prepare use case and PR. :)