### PR TITLE
refactor check attribute name

### DIFF
--- a/lib/lotus/entity.rb
+++ b/lib/lotus/entity.rb
@@ -140,15 +140,13 @@ module Lotus
       #   DeletedUser.attributes => #<Set: {:id, :name, :deleted_at}>
       #
       def attributes(*attrs)
-        if attrs.any?
-          attrs = Lotus::Utils::Kernel.Array(attrs)
-          self.attributes.merge attrs
+        return @attributes ||= Set.new unless attrs.any?
 
-          attrs.each do |attr|
-            define_attr_accessor(attr) if defined_attribute?(attr)
+        Lotus::Utils::Kernel.Array(attrs).each do |attr|
+          if allowed_attribute_name?(attr)
+            define_attr_accessor(attr)
+            self.attributes << attr
           end
-        else
-          @attributes ||= Set.new
         end
       end
 
@@ -164,11 +162,10 @@ module Lotus
 
       # Check if attr_reader define the given attribute
       #
-      # @since 0.3.1
+      # @since 0.5.1
       # @api private
-      def defined_attribute?(name)
-        name == :id ||
-          !instance_methods.include?(name)
+      def allowed_attribute_name?(name)
+        !instance_methods.include?(name)
       end
 
       protected

--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -38,11 +38,31 @@ describe Lotus::Entity do
       Car.attributes.must_equal Set.new([:id, :model])
     end
 
+    it 'rejects existed instance methods' do
+      Car.attributes :object_id
+      Car.attributes.must_equal Set.new([:id])
+    end
+
     describe 'params is array' do
       it 'defines attributes' do
         Car.attributes [:model]
         Car.attributes.must_equal Set.new([:id, :model])
       end
+    end
+  end
+
+  describe '.allowed_attribute_name?' do
+    it 'returns true if attrubute not defined' do
+      Car.allowed_attribute_name?(:model).must_equal true
+    end
+
+    it 'returns false if attribute defined' do
+      Car.attributes :model
+      Car.allowed_attribute_name?(:model).must_equal false
+    end
+
+    it 'returns false for reserved word' do
+      Car.allowed_attribute_name?(:to_json).must_equal false
     end
   end
 


### PR DESCRIPTION
Currently `defined_attribute?` has strange realization and usage. It checks name on inclusion in `instance_methods`.
Next point that attrubute wil be added to attribute list even if `defined_attribute?(attr)` returns `false`

I suggest small fixes: 
– rename to `allowed_attribute_name?`. Method name is clear for understanding
– add to attributes only allowed by name instead of all. It helps to avoid duplicated attributes too.
– add tests on this logic