### PR TITLE
Entity identity

### DIFF
--- a/lib/lotus/model/adapters/implementation.rb
+++ b/lib/lotus/model/adapters/implementation.rb
@@ -16,7 +16,7 @@ module Lotus
         # @api private
         # @since 0.1.0
         def persist(collection, entity)
-          if entity.id
+          if entity.identity
             update(collection, entity)
           else
             create(collection, entity)

--- a/lib/lotus/model/adapters/memory/collection.rb
+++ b/lib/lotus/model/adapters/memory/collection.rb
@@ -104,7 +104,7 @@ module Lotus
           # @api private
           # @since 0.1.0
           def delete(entity)
-            records.delete(entity.id)
+            records.delete(entity.identity)
           end
 
           # Returns all the raw records

--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -75,7 +75,7 @@ module Lotus
         # @since 0.1.0
         def update(collection, entity)
           command(
-            _find(collection, entity.id)
+            _find(collection, entity.identity)
           ).update(entity)
         end
 
@@ -88,7 +88,7 @@ module Lotus
         # @since 0.1.0
         def delete(collection, entity)
           command(
-            _find(collection, entity.id)
+            _find(collection, entity.identity)
           ).delete
         end
 

--- a/lib/lotus/model/mapping/collection_coercer.rb
+++ b/lib/lotus/model/mapping/collection_coercer.rb
@@ -55,7 +55,7 @@ module Lotus
 
           instance_eval <<-EVAL, __FILE__, __LINE__
             def to_record(entity)
-              if entity.id
+              if entity.identity
                 Hash[#{ @collection.attributes.map{|name,attr| ":#{ attr.mapped },#{ attr.dump_coercer }(entity.#{name})"}.join(',') }]
               else
                 Hash[].tap do |record|

--- a/lib/lotus/repository.rb
+++ b/lib/lotus/repository.rb
@@ -833,7 +833,7 @@ module Lotus
       # @return a boolean value
       # @since 0.3.1
       def _persisted?(entity)
-        !!entity.id
+        !!entity.identity
       end
 
       # Update timestamps

--- a/test/entity_test.rb
+++ b/test/entity_test.rb
@@ -343,4 +343,64 @@ describe Lotus::Entity do
       end
     end
   end
+
+  describe '#identity' do
+    describe 'default behavior' do
+      it 'sets :id' do
+        Car.identity.must_equal :id
+      end
+
+      describe ".attributes" do
+        it 'defines :identity by default' do
+          Car.attributes.must_equal Set.new([:id])
+        end
+      end
+
+      describe "#id" do
+        it 'is accessible' do
+          car = Car.new
+          car.id = 100
+          car.id.must_equal 100
+        end
+      end
+    end
+
+    describe 'new value' do
+      before do
+        class Post
+          include Lotus::Entity
+          identity :uuid
+
+          attributes :name
+        end
+      end
+
+      it 'sets new identity' do
+        Post.identity :uuid
+        Post.identity.must_equal :uuid
+      end
+
+      it 'replaces old identity' do
+        Post.attributes.must_equal Set.new([:uuid, :name])
+        post = Post.new
+        proc{post.id}.must_raise NoMethodError
+        proc{post.id = 100}.must_raise NoMethodError
+      end
+
+      it 'sets new attribute' do
+        Post.attributes.must_equal Set.new([:uuid, :name])
+        post = Post.new
+        post.uuid = 100
+        post.uuid.must_equal 100
+      end
+    end
+  end
+
+  describe ".identity" do
+    let(:book) { Book.new(id: 23, title: 'Wuthering Meadow', author: 'J. K. Rowling', published: true ) }
+
+    it 'returns identity value' do
+      book.identity.must_equal 23
+    end
+  end
 end


### PR DESCRIPTION
I suggest to have entity identity configurable instead of hard-coced `:id`. In some cases it may be `uuid` for example

```ruby
require 'lotus/model'
class User
  include Lotus::Entity
  identity :uuid
end
```
It compatible with existed models because default entity identity is `:id`.
