### PR TITLE
database busy exception test

### DIFF
--- a/test/integration/migrations_test.rb
+++ b/test/integration/migrations_test.rb
@@ -399,6 +399,13 @@ describe "Database migrations" do
         exception = -> { Lotus::Model::Migrator.drop }.must_raise Lotus::Model::MigrationError
         exception.message.must_equal "Cannot find database: #{ @database }"
       end
+
+      it 'raises error if database is busy' do
+        Sequel.connect(@uri).tables
+        exception = -> { Lotus::Model::Migrator.drop }.must_raise Lotus::Model::MigrationError
+        exception.message.must_include 'dropdb: database removal failed'
+        exception.message.must_include 'There is 1 other session using the database'
+      end
     end
 
     describe "migrate" do


### PR DESCRIPTION
I've tried to fix #250 by repeating steps, but it has very informative output (`lotus-model` from `master`):
```
/Users/ad/code/tmp/model/lib/lotus/model/migrator/postgres_adapter.rb:51:in `block in drop': dropdb: database removal failed: ERROR:  database "bookshelf_development" is being accessed by other users (Lotus::Model::MigrationError)
DETAIL:  There is 1 other session using the database.
```

So #250 could be closed without PR, I just added only test that exception has message from database.