### PR TITLE
[b] Improve error message for `lotus db prepare`

### DIFF
--- a/lib/lotus/model/migrator/mysql_adapter.rb
+++ b/lib/lotus/model/migrator/mysql_adapter.rb
@@ -10,6 +10,14 @@ module Lotus
         # @api private
         def create
           new_connection(global: true).run %(CREATE DATABASE #{ database };)
+        rescue Sequel::DatabaseError => e
+          message = if e.message.match(/database exists/)
+            "Database creation failed. There is 1 other session using the database"
+          else
+            e.message
+          end
+
+          raise MigrationError.new(message)
         end
 
         # @since 0.4.0

--- a/lib/lotus/model/migrator/postgres_adapter.rb
+++ b/lib/lotus/model/migrator/postgres_adapter.rb
@@ -26,7 +26,16 @@ module Lotus
         # @api private
         def create
           set_environment_variables
-          `createdb #{ database }`
+
+          call_db_command('createdb') do |error_message|
+            message = if error_message.match(/already exists/)
+              "createdb: database creation failed. There is 1 other session using the database."
+            else
+              error_message
+            end
+
+            raise MigrationError.new(message)
+          end
         end
 
         # @since 0.4.0
@@ -34,22 +43,14 @@ module Lotus
         def drop
           set_environment_variables
 
-          require 'open3'
-
-          Open3.popen3('dropdb', database) do |stdin, stdout, stderr, wait_thr|
-            exit_status = wait_thr.value
-
-            unless exit_status.success?
-              error_message = stderr.read
-
-              message = if error_message.match(/does not exist/)
-                "Cannot find database: #{ database }"
-              else
-                error_message
-              end
-
-              raise MigrationError.new(message)
+          call_db_command('dropdb') do |error_message|
+            message = if error_message.match(/does not exist/)
+              "Cannot find database: #{ database }"
+            else
+              error_message
             end
+
+            raise MigrationError.new(message)
           end
         end
 
@@ -95,6 +96,20 @@ module Lotus
         # @api private
         def dump_migrations_data
           system "pg_dump -t #{ migrations_table } #{ database } >> #{ escape(schema) }"
+        end
+
+        # @since x.x.x
+        # @api private
+        def call_db_command(command)
+          require 'open3'
+
+          Open3.popen3(command, database) do |stdin, stdout, stderr, wait_thr|
+            exit_status = wait_thr.value
+
+            unless exit_status.success?
+              yield stderr.read
+            end
+          end
         end
       end
     end

--- a/test/integration/migration/mysql_test.rb
+++ b/test/integration/migration/mysql_test.rb
@@ -30,11 +30,20 @@ describe 'Mysql database migrations' do
     end
 
     describe "create" do
-      it "creates the database" do
+      before do
         Lotus::Model::Migrator.create
+      end
 
+      it "creates the database" do
         connection = Sequel.connect(@uri)
         connection.tables.must_be :empty?
+      end
+
+      it 'raises error if database is busy' do
+        Sequel.connect(@uri).tables
+        exception = -> { Lotus::Model::Migrator.create }.must_raise Lotus::Model::MigrationError
+        exception.message.must_include 'Database creation failed'
+        exception.message.must_include 'There is 1 other session using the database'
       end
     end
 

--- a/test/integration/migration/postgres_test.rb
+++ b/test/integration/migration/postgres_test.rb
@@ -31,11 +31,20 @@ describe 'PostgreSQL Database migrations' do
     end
 
     describe "create" do
-      it "creates the database" do
+      before do
         Lotus::Model::Migrator.create
+      end
 
+      it "creates the database" do
         connection = Sequel.connect(@uri)
         connection.tables.must_be :empty?
+      end
+
+      it 'raises error if database is busy' do
+        Sequel.connect(@uri).tables
+        exception = -> { Lotus::Model::Migrator.create }.must_raise Lotus::Model::MigrationError
+        exception.message.must_include 'createdb: database creation failed'
+        exception.message.must_include 'There is 1 other session using the database'
       end
     end
 


### PR DESCRIPTION
# The bugs:

- Step to reproduce:

```shell
% lotus new bookshelf --database=postgres && cd bookshelf && bundle
% bundle exec lotus db prepare
```

- Open another shell and left open the PG client

```shell
% psql bookshelf_development
```

- Get back to the initial shell:

```shell
% bundle exec lotus db prepare
createdb: database creation failed: ERROR:  database "some_database" already exists
```

# The fixes:
Instead of this error:
```shell
createdb: database creation failed: ERROR:  database "some_database" already exists
```

Now it will return
```shell
Database creation failed. There is 1 other session using the database.
```
Fix https://github.com/lotus/model/issues/251