### PR TITLE
Allow an after_connect callback for repo adapters

### DIFF
--- a/lib/lotus/model/adapters/abstract.rb
+++ b/lib/lotus/model/adapters/abstract.rb
@@ -85,6 +85,8 @@ module Lotus
         #
         # @param uri [String] the optional connection string to the database
         #
+        # @param options [Hash] a list of non-mandatory adapter options
+        #
         # @since 0.1.0
         def initialize(mapper, uri = nil, options = {})
           @mapper = mapper

--- a/lib/lotus/model/adapters/abstract.rb
+++ b/lib/lotus/model/adapters/abstract.rb
@@ -86,9 +86,10 @@ module Lotus
         # @param uri [String] the optional connection string to the database
         #
         # @since 0.1.0
-        def initialize(mapper, uri = nil)
+        def initialize(mapper, uri = nil, callbacks = {})
           @mapper = mapper
           @uri    = uri
+          @callbacks = callbacks
         end
 
         # Creates or updates a record in the database for the given entity.

--- a/lib/lotus/model/adapters/abstract.rb
+++ b/lib/lotus/model/adapters/abstract.rb
@@ -86,10 +86,10 @@ module Lotus
         # @param uri [String] the optional connection string to the database
         #
         # @since 0.1.0
-        def initialize(mapper, uri = nil, callbacks = {})
+        def initialize(mapper, uri = nil, options = {})
           @mapper = mapper
           @uri    = uri
-          @callbacks = callbacks
+          @options = options
         end
 
         # Creates or updates a record in the database for the given entity.

--- a/lib/lotus/model/adapters/file_system_adapter.rb
+++ b/lib/lotus/model/adapters/file_system_adapter.rb
@@ -66,7 +66,7 @@ module Lotus
         #
         # @api private
         # @since 0.2.0
-        def initialize(mapper, uri)
+        def initialize(mapper, uri, callbacks = {})
           super
           prepare(uri)
 

--- a/lib/lotus/model/adapters/file_system_adapter.rb
+++ b/lib/lotus/model/adapters/file_system_adapter.rb
@@ -59,6 +59,7 @@ module Lotus
         #
         # @param mapper [Object] the database mapper
         # @param uri [String] the connection uri
+        # @param options [Hash] a hash of non-mandatory adapter options
         #
         # @return [Lotus::Model::Adapters::FileSystemAdapter]
         #

--- a/lib/lotus/model/adapters/file_system_adapter.rb
+++ b/lib/lotus/model/adapters/file_system_adapter.rb
@@ -66,7 +66,7 @@ module Lotus
         #
         # @api private
         # @since 0.2.0
-        def initialize(mapper, uri, callbacks = {})
+        def initialize(mapper, uri, options = {})
           super
           prepare(uri)
 

--- a/lib/lotus/model/adapters/memory_adapter.rb
+++ b/lib/lotus/model/adapters/memory_adapter.rb
@@ -24,6 +24,7 @@ module Lotus
         #
         # @param mapper [Object] the database mapper
         # @param uri [String] the connection uri (ignored)
+        # @param options [Hash] a hash of non mandatory adapter options
         #
         # @return [Lotus::Model::Adapters::MemoryAdapter]
         #
@@ -31,10 +32,8 @@ module Lotus
         #
         # @api private
         # @since 0.1.0
-        def initialize(mapper, uri = nil, callbacks = {})
+        def initialize(mapper, uri = nil, options = {})
           super
-
-          execute_callbacks
 
           @mutex       = Mutex.new
           @collections = {}
@@ -152,10 +151,6 @@ module Lotus
         end
 
         private
-
-        def execute_callbacks
-          @callbacks.each_pair { |_, callback| callback.call(self) }
-        end
 
         # Returns a collection from the given name.
         #

--- a/lib/lotus/model/adapters/memory_adapter.rb
+++ b/lib/lotus/model/adapters/memory_adapter.rb
@@ -31,8 +31,10 @@ module Lotus
         #
         # @api private
         # @since 0.1.0
-        def initialize(mapper, uri = nil)
+        def initialize(mapper, uri = nil, callbacks = {})
           super
+
+          execute_callbacks
 
           @mutex       = Mutex.new
           @collections = {}
@@ -150,6 +152,10 @@ module Lotus
         end
 
         private
+
+        def execute_callbacks
+          @callbacks.each_pair { |_, callback| callback.call(self) }
+        end
 
         # Returns a collection from the given name.
         #

--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -28,6 +28,7 @@ module Lotus
         #
         # @param mapper [Object] the database mapper
         # @param uri [String] the connection uri for the database
+        # @param options [Hash] a hash of non-mandatory adapter options
         #
         # @return [Lotus::Model::Adapters::SqlAdapter]
         #
@@ -41,9 +42,9 @@ module Lotus
         #
         # @api private
         # @since 0.1.0
-        def initialize(mapper, uri, callbacks = {})
+        def initialize(mapper, uri, options = {})
           super
-          @connection = Sequel.connect(@uri, @callbacks)
+          @connection = Sequel.connect(@uri, @options)
         rescue Sequel::AdapterNotFound => e
           raise DatabaseAdapterNotFound.new(e.message)
         end

--- a/lib/lotus/model/adapters/sql_adapter.rb
+++ b/lib/lotus/model/adapters/sql_adapter.rb
@@ -41,9 +41,9 @@ module Lotus
         #
         # @api private
         # @since 0.1.0
-        def initialize(mapper, uri)
+        def initialize(mapper, uri, callbacks = {})
           super
-          @connection = Sequel.connect(@uri)
+          @connection = Sequel.connect(@uri, @callbacks)
         rescue Sequel::AdapterNotFound => e
           raise DatabaseAdapterNotFound.new(e.message)
         end

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -46,17 +46,6 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
   let(:collection) { :users }
 
-  describe 'initialize' do
-    it 'executes after_connect callback' do
-      spy = nil
-      after_connect_spy_proc = Proc.new { spy = true }
-
-      adapter = Lotus::Model::Adapters::MemoryAdapter.new(@mapper, nil, after_connect: after_connect_spy_proc)
-
-      spy.must_equal true
-    end
-  end
-
   describe 'multiple collections' do
     it 'create records' do
       user   = TestUser.new

--- a/test/model/adapters/memory_adapter_test.rb
+++ b/test/model/adapters/memory_adapter_test.rb
@@ -46,6 +46,17 @@ describe Lotus::Model::Adapters::MemoryAdapter do
 
   let(:collection) { :users }
 
+  describe 'initialize' do
+    it 'executes after_connect callback' do
+      spy = nil
+      after_connect_spy_proc = Proc.new { spy = true }
+
+      adapter = Lotus::Model::Adapters::MemoryAdapter.new(@mapper, nil, after_connect: after_connect_spy_proc)
+
+      spy.must_equal true
+    end
+  end
+
   describe 'multiple collections' do
     it 'create records' do
       user   = TestUser.new

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -149,7 +149,7 @@ describe Lotus::Model::Adapters::SqlAdapter do
       }.must_raise(URI::InvalidURIError)
     end
 
-    it 'executes after_connect callbacks' do
+    it 'supports non-mandatory adapter configurations' do
       spy = nil
       after_connect_spy_proc = Proc.new { spy = true }
 

--- a/test/model/adapters/sql_adapter_test.rb
+++ b/test/model/adapters/sql_adapter_test.rb
@@ -148,6 +148,20 @@ describe Lotus::Model::Adapters::SqlAdapter do
         Lotus::Model::Adapters::SqlAdapter.new(@mapper, 'unknown_db:host')
       }.must_raise(URI::InvalidURIError)
     end
+
+    it 'executes after_connect callbacks' do
+      spy = nil
+      after_connect_spy_proc = Proc.new { spy = true }
+
+      adapter = Lotus::Model::Adapters::SqlAdapter.new(@mapper,
+                                                        SQLITE_CONNECTION_STRING, after_connect: after_connect_spy_proc)
+
+      # Sequel lazily connects
+      adapter.execute('select 1 as dummy')
+
+      spy.must_equal true
+    end
+
   end
 
   describe '#persist' do

--- a/test/model/config/adapter_test.rb
+++ b/test/model/config/adapter_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 describe Lotus::Model::Config::Adapter do
 
   describe 'initialize' do
-    it 'sets after_connect callback' do
+    it 'sets other adapater options' do
       after_connect_proc = -> {}
       config =  Lotus::Model::Config::Adapter.new(type: :memory, uri: nil, after_connect: after_connect_proc)
 
-      config.callbacks.must_equal({after_connect: after_connect_proc})
+      config.options.must_equal({after_connect: after_connect_proc})
     end
   end
 

--- a/test/model/config/adapter_test.rb
+++ b/test/model/config/adapter_test.rb
@@ -2,6 +2,15 @@ require 'test_helper'
 
 describe Lotus::Model::Config::Adapter do
 
+  describe 'initialize' do
+    it 'sets after_connect callback' do
+      after_connect_proc = -> {}
+      config =  Lotus::Model::Config::Adapter.new(type: :memory, uri: nil, after_connect: after_connect_proc)
+
+      config.callbacks.must_equal({after_connect: after_connect_proc})
+    end
+  end
+
   describe '#build' do
     let(:mapper) { Lotus::Model::Mapper.new }
     let(:adapter) { config.build(mapper) }


### PR DESCRIPTION
I needed to be able to access the underlying connection object from Sequel in order to turn on auto commit for a jdbc connection. Since Sequel has an `after_connect` callback I tried to expose it to lotus-model in a reasonable way as well as provide support for the same callback to other repositories for consistency.  Some notes about `after_connect` and its uses: http://sequel.jeremyevans.net/rdoc/files/doc/release_notes/3_11_0_txt.html

My usecase looks like:

```
Lotus::Model.configure do
  adapter type: :sql, uri: 'jdbc:...', after_connect: Proc.new { |connection| connection.auto_commit(true) }

  mapping do
  end
end
```

Please let me know your thoughts about the idea :)