### PR TITLE
Catch SystemCallError, in case command doesn't exist

### DIFF
--- a/lib/lotus/model/migrator/postgres_adapter.rb
+++ b/lib/lotus/model/migrator/postgres_adapter.rb
@@ -103,12 +103,14 @@ module Lotus
         def call_db_command(command)
           require 'open3'
 
-          Open3.popen3(command, database) do |stdin, stdout, stderr, wait_thr|
-            exit_status = wait_thr.value
-
-            unless exit_status.success?
-              yield stderr.read
+          begin
+            Open3.popen3(command, database) do |stdin, stdout, stderr, wait_thr|
+              unless wait_thr.value.success? # wait_thr.value is the exit status
+                yield stderr.read
+              end
             end
+          rescue SystemCallError => e
+            yield e.message
           end
         end
       end

--- a/test/integration/migration/postgres_test.rb
+++ b/test/integration/migration/postgres_test.rb
@@ -71,6 +71,23 @@ describe 'PostgreSQL Database migrations' do
         exception.message.must_include 'dropdb: database removal failed'
         exception.message.must_include 'There is 1 other session using the database'
       end
+
+      describe "when a command isn't available" do
+        before do
+          # We accomplish having a command not be available by setting PATH
+          # to an empty string, which means *no commands* are available.
+          @original_path = ENV['PATH']
+          ENV['PATH'] = ''
+        end
+
+        it "raises MigrationError on create" do
+          -> { Lotus::Model::Migrator.create }.must_raise Lotus::Model::MigrationError
+        end
+
+        after do
+          ENV['PATH'] = @original_path
+        end
+      end
     end
 
     describe "migrate" do


### PR DESCRIPTION
Closes #264.

I don't really like that we basically just change the `SystemCallError` into a `MigrationError`, without rescuing it, but that seems like another PR :)