### PR TITLE
Raise error when try use migrator class if the adapter isn't a db adapter

### DIFF
--- a/lib/lotus/model/migrator.rb
+++ b/lib/lotus/model/migrator.rb
@@ -292,6 +292,8 @@ module Lotus
         Sequel.connect(
           configuration.adapter.uri
         )
+      rescue Sequel::AdapterNotFound
+        raise MigrationError.new("Current adapter (#{ configuration.adapter.type }) doesn't support SQL database operations.")
       end
 
       # Lotus::Model configuration


### PR DESCRIPTION
This PR resolves lotus/lotus#417 

Rescue `Sequel::AdapterNotFound` when we use a non database adapter and raise a `MigrationError` class displaying a message that the current adapter doesn't support database operations

cc @lotus/core-team 