### PR TITLE
Improve NoAdapterError by mentioning `.load!`

### DIFF
--- a/lib/lotus/model/adapters/null_adapter.rb
+++ b/lib/lotus/model/adapters/null_adapter.rb
@@ -6,7 +6,9 @@ module Lotus
       # @since 0.2.0
       class NoAdapterError < Lotus::Model::Error
         def initialize(method_name)
-          super("Cannot invoke `#{ method_name }' on repository. Please check if `adapter' and `mapping' are set.")
+          super("Cannot invoke `#{ method_name }' on repository. "\
+                "Please check if `adapter' and `mapping' are set, "\
+                "and that you call `.load!' on the configuration.")
         end
       end
 

--- a/test/integration/configuration_test.rb
+++ b/test/integration/configuration_test.rb
@@ -42,7 +42,11 @@ describe 'Configuration DSL' do
   describe "when a repository isn't mapped" do
     it 'raises an error when try to use it' do
       exception = -> { UnmappedRepository.find(1) }.must_raise(Lotus::Model::Adapters::NoAdapterError)
-      exception.message.must_equal("Cannot invoke `find' on repository. Please check if `adapter' and `mapping' are set.")
+      exception.message.must_equal(
+        "Cannot invoke `find' on repository. "\
+        "Please check if `adapter' and `mapping' are set, "\
+        "and that you call `.load!' on the configuration."
+      )
     end
   end
 


### PR DESCRIPTION
Addresses #280.

I wrote code to solve this issue (by adding a `.loaded?` method to Lotus::Model::Configuration), but it added too much code, based on @jodosha's direction that he doesn't want to add a lot of code for this minor improvement.

I think this is better anyway, since it makes the error message more complete. Configurations need **3** things, and now the error message references all of them:

1. `adapter`
2. `mapping`
3. `.load!`


Also, I prefer multi-line strings to long lines, but I can switch them to long single lines if that's preferable.